### PR TITLE
feat(dashboard): search, sort and status filters on the list pages

### DIFF
--- a/dashboard/src/components/FilterChips.tsx
+++ b/dashboard/src/components/FilterChips.tsx
@@ -1,0 +1,36 @@
+import { cn } from '@/lib/utils'
+
+/**
+ * FilterChips is the row of status buttons every list page filters by — the
+ * Events page's severity chips, generalised so four pages don't grow four
+ * slightly different chip rows.
+ */
+export function FilterChips<F extends string>({
+  options,
+  value,
+  onChange,
+}: {
+  options: readonly { value: F; label: string }[]
+  value: F
+  onChange: (value: F) => void
+}) {
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {options.map((option) => (
+        <button
+          key={option.value}
+          type="button"
+          onClick={() => onChange(option.value)}
+          className={cn(
+            'rounded-md border px-3 py-1 text-xs transition-colors',
+            value === option.value
+              ? 'border-status-warn/60 font-medium text-primary'
+              : 'border-border text-muted-foreground hover:bg-muted hover:text-foreground',
+          )}
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/dashboard/src/components/SortHeader.tsx
+++ b/dashboard/src/components/SortHeader.tsx
@@ -1,0 +1,49 @@
+import { ChevronDown, ChevronUp, ChevronsUpDown } from 'lucide-react'
+import { TH } from '@/components/ui/table'
+import { cn } from '@/lib/utils'
+import type { Sort } from '@/hooks/useSort'
+
+/**
+ * SortHeader is a TH the reader can click to sort by that column.
+ *
+ * The double chevron on an inactive column is the affordance — without it a
+ * sortable header and a plain one are indistinguishable, and the feature only
+ * exists for whoever happens to click a label.
+ */
+export function SortHeader<K extends string>({
+  sort,
+  sortKey,
+  className,
+  children,
+}: {
+  sort: Sort<K>
+  sortKey: K
+  className?: string | undefined
+  children: React.ReactNode
+}) {
+  const active = sort.key === sortKey
+  return (
+    <TH
+      aria-sort={active ? (sort.dir === 'asc' ? 'ascending' : 'descending') : undefined}
+      className={className}
+    >
+      <button
+        type="button"
+        onClick={() => sort.toggle(sortKey)}
+        className={cn(
+          'inline-flex items-center gap-1 uppercase tracking-wider transition-colors hover:text-foreground',
+          active && 'text-foreground',
+        )}
+      >
+        {children}
+        {!active ? (
+          <ChevronsUpDown size={12} aria-hidden className="opacity-40" />
+        ) : sort.dir === 'asc' ? (
+          <ChevronUp size={12} aria-hidden />
+        ) : (
+          <ChevronDown size={12} aria-hidden />
+        )}
+      </button>
+    </TH>
+  )
+}

--- a/dashboard/src/hooks/useSort.test.ts
+++ b/dashboard/src/hooks/useSort.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+import { sortItems, useSort } from '@/hooks/useSort'
+
+describe('useSort', () => {
+  it('cycles a header asc → desc → back to the list order', () => {
+    const { result } = renderHook(() => useSort<'name'>())
+    expect(result.current.key).toBeNull()
+
+    act(() => result.current.toggle('name'))
+    expect(result.current).toMatchObject({ key: 'name', dir: 'asc' })
+
+    act(() => result.current.toggle('name'))
+    expect(result.current).toMatchObject({ key: 'name', dir: 'desc' })
+
+    // The third click restores the order the server chose — the only way back
+    // that is not "reload the page".
+    act(() => result.current.toggle('name'))
+    expect(result.current.key).toBeNull()
+  })
+
+  it('starts a different column ascending, whatever the previous one was', () => {
+    const { result } = renderHook(() => useSort<'name' | 'allocs'>())
+    act(() => result.current.toggle('name'))
+    act(() => result.current.toggle('name'))
+    expect(result.current.dir).toBe('desc')
+
+    act(() => result.current.toggle('allocs'))
+    expect(result.current).toMatchObject({ key: 'allocs', dir: 'asc' })
+  })
+})
+
+describe('sortItems', () => {
+  const byValue = { value: (item: { value: number | undefined }) => item.value }
+
+  it('returns the list itself while no column is active', () => {
+    const items = [{ value: 2 }, { value: 1 }]
+    expect(sortItems(items, { key: null, dir: 'asc' }, byValue)).toBe(items)
+  })
+
+  it('orders numbers both ways without mutating the input', () => {
+    const items = [{ value: 2 }, { value: 3 }, { value: 1 }]
+    expect(sortItems(items, { key: 'value', dir: 'asc' }, byValue).map((i) => i.value)).toEqual([
+      1, 2, 3,
+    ])
+    expect(sortItems(items, { key: 'value', dir: 'desc' }, byValue).map((i) => i.value)).toEqual([
+      3, 2, 1,
+    ])
+    expect(items.map((i) => i.value)).toEqual([2, 3, 1])
+  })
+
+  it('orders strings with localeCompare', () => {
+    const items = [{ name: 'web/api' }, { name: 'blog/site' }]
+    const sorted = sortItems(items, { key: 'name', dir: 'asc' }, { name: (i) => i.name })
+    expect(sorted.map((i) => i.name)).toEqual(['blog/site', 'web/api'])
+  })
+
+  it('sorts "no data" last in both directions', () => {
+    // A dash is not a small number: descending P95 means "slowest first", and
+    // an unmeasured service belongs at the bottom either way.
+    const items = [{ value: undefined }, { value: 5 }, { value: undefined }, { value: 1 }]
+    expect(sortItems(items, { key: 'value', dir: 'asc' }, byValue).map((i) => i.value)).toEqual([
+      1, 5, undefined, undefined,
+    ])
+    expect(sortItems(items, { key: 'value', dir: 'desc' }, byValue).map((i) => i.value)).toEqual([
+      5, 1, undefined, undefined,
+    ])
+  })
+
+  it('keeps equal rows in their incoming order', () => {
+    const items = [
+      { id: 'a', rank: 1 },
+      { id: 'b', rank: 0 },
+      { id: 'c', rank: 1 },
+    ]
+    const sorted = sortItems(items, { key: 'rank', dir: 'asc' }, { rank: (i) => i.rank })
+    expect(sorted.map((i) => i.id)).toEqual(['b', 'a', 'c'])
+  })
+})

--- a/dashboard/src/hooks/useSort.ts
+++ b/dashboard/src/hooks/useSort.ts
@@ -1,0 +1,63 @@
+import { useState } from 'react'
+
+export type SortDir = 'asc' | 'desc'
+
+export interface Sort<K extends string> {
+  /** key is null while the list is in its own order — the order the server
+   * chose, which every page treats as the default. */
+  key: K | null
+  dir: SortDir
+  toggle: (key: K) => void
+}
+
+/**
+ * useSort holds which column a table is sorted by.
+ *
+ * Clicking a header cycles asc → desc → back to the list's own order. The
+ * third state matters: a services list arrives named-ordered and a run list
+ * arrives newest-first, and once a reader has sorted by allocs there must be a
+ * way back to that order that is not "reload the page".
+ */
+export function useSort<K extends string>(): Sort<K> {
+  const [state, setState] = useState<{ key: K | null; dir: SortDir }>({ key: null, dir: 'asc' })
+  return {
+    ...state,
+    toggle: (key) =>
+      setState((s) => {
+        if (s.key !== key) return { key, dir: 'asc' }
+        if (s.dir === 'asc') return { key, dir: 'desc' }
+        return { key: null, dir: 'asc' }
+      }),
+  }
+}
+
+/** SortValue is what a column can order by. undefined means "no data". */
+export type SortValue = string | number | undefined
+
+/**
+ * sortItems orders a list by the active column, stably, without mutating it.
+ *
+ * "No data" sorts last in *both* directions — the dashboard's dashes are not
+ * small numbers ("no data is never zero"), and a reader sorting P95 descending
+ * is looking for the slowest service, not for the ones nothing has measured.
+ */
+export function sortItems<T, K extends string>(
+  items: T[],
+  sort: { key: K | null; dir: SortDir },
+  accessors: Record<K, (item: T) => SortValue>,
+): T[] {
+  if (sort.key === null) return items
+  const get = accessors[sort.key]
+  const sign = sort.dir === 'asc' ? 1 : -1
+  return [...items].sort((a, b) => {
+    const va = get(a)
+    const vb = get(b)
+    if (va === undefined && vb === undefined) return 0
+    if (va === undefined) return 1
+    if (vb === undefined) return -1
+    if (typeof va === 'string' && typeof vb === 'string') return sign * va.localeCompare(vb)
+    if (va < vb) return -sign
+    if (va > vb) return sign
+    return 0
+  })
+}

--- a/dashboard/src/lib/pipelines.ts
+++ b/dashboard/src/lib/pipelines.ts
@@ -39,12 +39,19 @@ export function runStateLabel(state: string): string {
  * that kept climbing after a build ended would be a lie about a finished thing.
  */
 export function runDuration(run: Run, now: number = Date.now()): string {
+  const ms = runDurationMs(run, now)
+  return ms === undefined ? '—' : humanDuration(ms)
+}
+
+/** runDurationMs is the same number before rendering — what a sorted Duration
+ * column compares, where "unparseable" must stay distinct from "instant". */
+export function runDurationMs(run: Run, now: number = Date.now()): number | undefined {
   const started = Date.parse(run.started_at)
-  if (!Number.isFinite(started)) return '—'
+  if (!Number.isFinite(started)) return undefined
 
   const ended = run.finished_at ? Date.parse(run.finished_at) : now
-  if (!Number.isFinite(ended)) return '—'
-  return humanDuration(Math.max(0, ended - started))
+  if (!Number.isFinite(ended)) return undefined
+  return Math.max(0, ended - started)
 }
 
 /** stepDuration is the same for one step. */

--- a/dashboard/src/lib/search.test.ts
+++ b/dashboard/src/lib/search.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { matchesQuery } from '@/lib/search'
+
+describe('matchesQuery', () => {
+  it('matches a case-insensitive substring in any field', () => {
+    expect(matchesQuery('API', 'web/api-server', 'nginx:1.27')).toBe(true)
+    expect(matchesQuery('nginx', 'web/api-server', 'nginx:1.27')).toBe(true)
+    expect(matchesQuery('postgres', 'web/api-server', 'nginx:1.27')).toBe(false)
+  })
+
+  it('matches everything on an empty or whitespace query', () => {
+    // A cleared search box is the unfiltered list, not an empty one.
+    expect(matchesQuery('', 'anything')).toBe(true)
+    expect(matchesQuery('   ', 'anything')).toBe(true)
+    expect(matchesQuery('', undefined)).toBe(true)
+  })
+
+  it('skips absent fields rather than matching on them', () => {
+    expect(matchesQuery('undefined', undefined, 'real value')).toBe(false)
+  })
+})

--- a/dashboard/src/lib/search.ts
+++ b/dashboard/src/lib/search.ts
@@ -1,0 +1,11 @@
+/**
+ * matchesQuery is the dashboard's one search behaviour: a case-insensitive
+ * substring match over the fields a row actually shows. An empty or
+ * whitespace-only query matches everything, so a cleared search box is the
+ * unfiltered list rather than an empty one.
+ */
+export function matchesQuery(query: string, ...haystacks: (string | undefined)[]): boolean {
+  const q = query.trim().toLowerCase()
+  if (q === '') return true
+  return haystacks.some((h) => h !== undefined && h.toLowerCase().includes(q))
+}

--- a/dashboard/src/pages/Events.tsx
+++ b/dashboard/src/pages/Events.tsx
@@ -12,13 +12,21 @@ import {
   type KaneaEvent,
 } from '@/lib/api'
 import { eventScope, eventSource, matchGlob } from '@/lib/events'
+import { matchesQuery } from '@/lib/search'
 import { formatClock } from '@/lib/state'
-import { cn } from '@/lib/utils'
 import { useSession } from '@/hooks/useSession'
 import { usePagination } from '@/hooks/usePagination'
 import { PaginationControls } from '@/components/Pagination'
+import { FilterChips } from '@/components/FilterChips'
 
-type Filter = 'all' | 'info' | 'warning' | 'error' | 'audit'
+const filters = [
+  { value: 'all', label: 'all' },
+  { value: 'info', label: 'info' },
+  { value: 'warning', label: 'warning' },
+  { value: 'error', label: 'error' },
+  { value: 'audit', label: 'audit' },
+] as const
+type Filter = (typeof filters)[number]['value']
 
 const severityVariant: Record<KaneaEvent['severity'], 'info' | 'warn' | 'error'> = {
   info: 'info',
@@ -43,6 +51,7 @@ const severityVariant: Record<KaneaEvent['severity'], 'info' | 'warn' | 'error'>
 export function Events() {
   const [filter, setFilter] = useState<Filter>('all')
   const [glob, setGlob] = useState('')
+  const [query, setQuery] = useState('')
   const { session } = useSession()
 
   const feed = useQuery({
@@ -74,13 +83,16 @@ export function Events() {
   const events = (feed.data?.events ?? []).filter(
     (event) =>
       (filter === 'all' || event.severity === filter) &&
-      (glob.trim() === '' || matchGlob(glob, eventScope(event))),
+      (glob.trim() === '' || matchGlob(glob, eventScope(event))) &&
+      // The glob addresses the scope; the search reads the words. "db timeout"
+      // across every service and "payments/*" are different questions.
+      matchesQuery(query, event.message, event.detail, eventScope(event), eventSource(event)),
   )
   const dropped = feed.data?.dropped ?? 0
 
   // A changed filter resets to the first page: page 3 of "all" and page 3 of
   // "error" are unrelated places.
-  const pager = usePagination(events, { resetKey: `${glob} ${filter}` })
+  const pager = usePagination(events, { resetKey: `${glob} ${query} ${filter}` })
   const auditPager = usePagination(audit.data ?? [], { resetKey: filter })
 
   return (
@@ -88,34 +100,28 @@ export function Events() {
       <PageHeader title="Events" subtitle="notification feed · refreshes every 5s" />
 
       <div className="flex flex-wrap items-center justify-between gap-3">
-        <div className="flex gap-1.5">
-          {(['all', 'info', 'warning', 'error', 'audit'] as const).map((level) => (
-            <button
-              key={level}
-              type="button"
-              onClick={() => setFilter(level)}
-              className={cn(
-                'rounded-md border px-3 py-1 text-xs transition-colors',
-                filter === level
-                  ? 'border-status-warn/60 font-medium text-primary'
-                  : 'border-border text-muted-foreground hover:bg-muted hover:text-foreground',
-              )}
-            >
-              {level}
-            </button>
-          ))}
-        </div>
-        <label className="flex items-center gap-2 text-xs text-muted-foreground">
-          glob:
+        <FilterChips options={filters} value={filter} onChange={setFilter} />
+        <div className="flex flex-wrap items-center gap-2">
           <input
             type="search"
-            value={glob}
-            onChange={(e) => setGlob(e.target.value)}
-            placeholder="svc/*"
-            aria-label="Filter by project/service glob"
-            className="h-7 w-28 rounded-md border bg-background px-2 font-mono text-xs"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search messages…"
+            aria-label="Search event messages"
+            className="h-7 w-40 rounded-md border bg-background px-2 text-xs"
           />
-        </label>
+          <label className="flex items-center gap-2 text-xs text-muted-foreground">
+            glob:
+            <input
+              type="search"
+              value={glob}
+              onChange={(e) => setGlob(e.target.value)}
+              placeholder="svc/*"
+              aria-label="Filter by project/service glob"
+              className="h-7 w-28 rounded-md border bg-background px-2 font-mono text-xs"
+            />
+          </label>
+        </div>
       </div>
 
       {dropped > 0 && filter !== 'audit' ? (
@@ -142,7 +148,7 @@ export function Events() {
           ) : null}
           {feed.isSuccess && events.length === 0 ? (
             <p className="text-sm text-muted-foreground">
-              {filter === 'all' && !glob.trim()
+              {filter === 'all' && !glob.trim() && !query.trim()
                 ? 'Nothing has happened yet.'
                 : 'No events match that filter.'}
             </p>

--- a/dashboard/src/pages/Functions.tsx
+++ b/dashboard/src/pages/Functions.tsx
@@ -1,22 +1,44 @@
+import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { Link } from '@/lib/router'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
 import { Table, TBody, TD, TH, THead, TR } from '@/components/ui/table'
 import { PageHeader } from '@/components/PageHeader'
+import { FilterChips } from '@/components/FilterChips'
+import { SortHeader } from '@/components/SortHeader'
 import { StatTile } from '@/components/StatTile'
 import { StatusDot } from '@/components/StatusDot'
 import { useLiveTopic } from '@/hooks/useLiveTopic'
 import { usePagination } from '@/hooks/usePagination'
 import { PaginationControls } from '@/components/Pagination'
+import { sortItems, useSort } from '@/hooks/useSort'
 import {
   Topic,
   fetchFunctions,
   statsSampleSchema,
   type FunctionView,
 } from '@/lib/api'
+import { matchesQuery } from '@/lib/search'
 import { formatBytes, formatMetric } from '@/lib/state'
+
+/** The statuses internal/api's functions route derives (active / idle /
+ * trapping / stopped), as chips. */
+const statusFilters = [
+  { value: 'all', label: 'all' },
+  { value: 'active', label: 'active' },
+  { value: 'idle', label: 'idle' },
+  { value: 'trapping', label: 'trapping' },
+  { value: 'stopped', label: 'stopped' },
+] as const
+type StatusFilter = (typeof statusFilters)[number]['value']
+
+/** Ascending status sort reads problems-first. */
+const statusRank: Record<string, number> = { trapping: 0, active: 1, idle: 2, stopped: 3 }
+
+type SortKey = 'function' | 'invocations' | 'memory' | 'status'
 
 /**
  * Functions (v1.39): wasm functions — services underneath, so detail, restart
@@ -32,9 +54,29 @@ export function Functions() {
     refetchInterval: 10_000,
   })
 
-  const list = functions.data?.functions ?? []
-  const pager = usePagination(list)
+  const [query, setQuery] = useState('')
+  const [status, setStatus] = useState<StatusFilter>('all')
+  const sort = useSort<SortKey>()
 
+  const list = functions.data?.functions ?? []
+  const filtered = list.filter(
+    (fn) =>
+      (status === 'all' || fn.status === status) &&
+      matchesQuery(query, `${fn.project}/${fn.service}`, fn.module),
+  )
+  const sorted = sortItems(filtered, sort, {
+    function: (fn) => `${fn.project}/${fn.service}`,
+    // "No datapath sample" sorts after every measured rate, both ways.
+    invocations: (fn) => fn.invocations_per_minute,
+    memory: (fn) => fn.memory_bytes,
+    status: (fn) => statusRank[fn.status],
+  })
+  const pager = usePagination(sorted, {
+    resetKey: `${query} ${status} ${sort.key ?? ''} ${sort.dir}`,
+  })
+
+  // The tiles summarise everything declared, not the filtered view: "Active
+  // 3/9" must not become "3/3" because the reader is looking at a subset.
   const measured = list.filter((f) => f.invocations_per_minute !== undefined)
   const totalRate = measured.reduce((sum, f) => sum + (f.invocations_per_minute ?? 0), 0)
   const active = list.filter((f) => f.status === 'active').length
@@ -87,28 +129,58 @@ export function Functions() {
           declares one — a wasm module the platform runs for you.
         </Card>
       ) : (
-        <Card className="py-2">
-          <Table>
-            <THead>
-              <tr>
-                <TH className="pt-2">Function</TH>
-                <TH className="pt-2">Trigger</TH>
-                <TH className="pt-2">Inv/min</TH>
-                <TH className="pt-2">P95</TH>
-                <TH className="pt-2">Mem cap</TH>
-                <TH className="pt-2">Status</TH>
-              </tr>
-            </THead>
-            <TBody>
-              {pager.pageItems.map((fn) => (
-                <FunctionRow key={`${fn.project}/${fn.service}`} fn={fn} />
-              ))}
-            </TBody>
-          </Table>
-          <div className="px-3">
-            <PaginationControls state={pager} />
+        <>
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <FilterChips options={statusFilters} value={status} onChange={setStatus} />
+            <Input
+              type="search"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search name or module…"
+              aria-label="Search functions"
+              className="h-8 w-56 text-xs"
+            />
           </div>
-        </Card>
+
+          {sorted.length === 0 ? (
+            <Card className="p-4 text-sm text-muted-foreground">
+              No functions match that filter.
+            </Card>
+          ) : (
+            <Card className="py-2">
+              <Table>
+                <THead>
+                  <tr>
+                    <SortHeader sort={sort} sortKey="function" className="pt-2">
+                      Function
+                    </SortHeader>
+                    <TH className="pt-2">Trigger</TH>
+                    <SortHeader sort={sort} sortKey="invocations" className="pt-2">
+                      Inv/min
+                    </SortHeader>
+                    {/* P95 rides a per-row stats subscription; the page never
+                        holds it, so it cannot sort by it. */}
+                    <TH className="pt-2">P95</TH>
+                    <SortHeader sort={sort} sortKey="memory" className="pt-2">
+                      Mem cap
+                    </SortHeader>
+                    <SortHeader sort={sort} sortKey="status" className="pt-2">
+                      Status
+                    </SortHeader>
+                  </tr>
+                </THead>
+                <TBody>
+                  {pager.pageItems.map((fn) => (
+                    <FunctionRow key={`${fn.project}/${fn.service}`} fn={fn} />
+                  ))}
+                </TBody>
+              </Table>
+              <div className="px-3">
+                <PaginationControls state={pager} />
+              </div>
+            </Card>
+          )}
+        </>
       )}
 
       <p className="text-xs text-muted-foreground">

--- a/dashboard/src/pages/Pipelines.tsx
+++ b/dashboard/src/pages/Pipelines.tsx
@@ -1,14 +1,43 @@
+import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { ShieldCheck } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Card } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
 import { Table, TBody, TD, TH, THead, TR } from '@/components/ui/table'
 import { PageHeader } from '@/components/PageHeader'
+import { FilterChips } from '@/components/FilterChips'
+import { SortHeader } from '@/components/SortHeader'
 import { Link } from '@/lib/router'
 import { fetchRuns, isRunFinished, type Run } from '@/lib/api'
-import { runStateLabel, runStateVariant, runDuration, shortSHA } from '@/lib/pipelines'
+import { runStateLabel, runStateVariant, runDuration, runDurationMs, shortSHA } from '@/lib/pipelines'
+import { matchesQuery } from '@/lib/search'
 import { usePagination } from '@/hooks/usePagination'
 import { PaginationControls } from '@/components/Pagination'
+import { sortItems, useSort } from '@/hooks/useSort'
+
+/** The wire states as chips, labelled the way the status pills read
+ * (runStateLabel): a running run is "building", a succeeded one is "ok". */
+const stateFilters = [
+  { value: 'all', label: 'all' },
+  { value: 'running', label: 'building' },
+  { value: 'queued', label: 'queued' },
+  { value: 'succeeded', label: 'ok' },
+  { value: 'failed', label: 'failed' },
+  { value: 'cancelled', label: 'cancelled' },
+] as const
+type StateFilter = (typeof stateFilters)[number]['value']
+
+/** Ascending status sort reads live-first, then what needs attention. */
+const stateRank: Record<string, number> = {
+  running: 0,
+  queued: 1,
+  failed: 2,
+  succeeded: 3,
+  cancelled: 4,
+}
+
+type SortKey = 'repository' | 'status' | 'duration'
 
 /**
  * The pipeline list (PRD §10.2).
@@ -30,8 +59,31 @@ export function Pipelines() {
       (query.state.data ?? []).some((run) => !isRunFinished(run)) ? 2_000 : 15_000,
   })
 
+  const [query, setQuery] = useState('')
+  const [state, setState] = useState<StateFilter>('all')
+  const sort = useSort<SortKey>()
+
   const list = runs.data ?? []
-  const pager = usePagination(list)
+  const filtered = list.filter(
+    (run) =>
+      (state === 'all' || run.state === state) &&
+      matchesQuery(
+        query,
+        `${run.project}/${run.service}`,
+        run.ref,
+        run.commit,
+        run.trigger,
+        run.triggered_by,
+      ),
+  )
+  const sorted = sortItems(filtered, sort, {
+    repository: (run) => `${run.project}/${run.service}`,
+    status: (run) => stateRank[run.state],
+    duration: (run) => runDurationMs(run),
+  })
+  const pager = usePagination(sorted, {
+    resetKey: `${query} ${state} ${sort.key ?? ''} ${sort.dir}`,
+  })
   // The queue serialises builds and refuses when full (§10.2): one slot, in
   // use whenever a run is going.
   const building = list.some((run) => run.state === 'running')
@@ -56,27 +108,51 @@ export function Pipelines() {
           a push to its watched branch, or on <span className="font-mono">kanea build</span>.
         </Card>
       ) : (
-        <Card className="py-2">
-          <Table>
-            <THead>
-              <tr>
-                <TH className="pt-2">Repository</TH>
-                <TH className="pt-2">Trigger</TH>
-                <TH className="pt-2">Commit</TH>
-                <TH className="pt-2">Status</TH>
-                <TH className="pt-2">Duration</TH>
-              </tr>
-            </THead>
-            <TBody>
-              {pager.pageItems.map((run) => (
-                <RunRow key={`${run.project}/${run.service}/${run.id}`} run={run} />
-              ))}
-            </TBody>
-          </Table>
-          <div className="px-3">
-            <PaginationControls state={pager} />
+        <>
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <FilterChips options={stateFilters} value={state} onChange={setState} />
+            <Input
+              type="search"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search repo, ref or commit…"
+              aria-label="Search pipeline runs"
+              className="h-8 w-56 text-xs"
+            />
           </div>
-        </Card>
+
+          {sorted.length === 0 ? (
+            <Card className="p-4 text-sm text-muted-foreground">No runs match that filter.</Card>
+          ) : (
+            <Card className="py-2">
+              <Table>
+                <THead>
+                  <tr>
+                    <SortHeader sort={sort} sortKey="repository" className="pt-2">
+                      Repository
+                    </SortHeader>
+                    <TH className="pt-2">Trigger</TH>
+                    <TH className="pt-2">Commit</TH>
+                    <SortHeader sort={sort} sortKey="status" className="pt-2">
+                      Status
+                    </SortHeader>
+                    <SortHeader sort={sort} sortKey="duration" className="pt-2">
+                      Duration
+                    </SortHeader>
+                  </tr>
+                </THead>
+                <TBody>
+                  {pager.pageItems.map((run) => (
+                    <RunRow key={`${run.project}/${run.service}/${run.id}`} run={run} />
+                  ))}
+                </TBody>
+              </Table>
+              <div className="px-3">
+                <PaginationControls state={pager} />
+              </div>
+            </Card>
+          )}
+        </>
       )}
 
       <Card className="flex items-center gap-2.5 p-3 text-sm text-muted-foreground">

--- a/dashboard/src/pages/Services.tsx
+++ b/dashboard/src/pages/Services.tsx
@@ -1,10 +1,14 @@
+import { useState } from 'react'
 import { Link } from '@/lib/router'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
 import { Table, TBody, TD, TH, THead, TR } from '@/components/ui/table'
 import { PageHeader } from '@/components/PageHeader'
 import { StatusDot } from '@/components/StatusDot'
+import { FilterChips } from '@/components/FilterChips'
+import { SortHeader } from '@/components/SortHeader'
 import { useLiveTopic } from '@/hooks/useLiveTopic'
 import {
   Topic,
@@ -21,22 +25,64 @@ import {
   serviceHealth,
   serviceStatusTone,
 } from '@/lib/state'
+import { matchesQuery } from '@/lib/search'
 import { usePagination } from '@/hooks/usePagination'
 import { PaginationControls } from '@/components/Pagination'
+import { sortItems, useSort } from '@/hooks/useSort'
 
 /** When a service declares no p95 target, red starts here. */
 const defaultP95AlarmMs = 500
+
+/** The status words serviceStatusTone can produce, as filter chips. */
+const statusFilters = [
+  { value: 'all', label: 'all' },
+  { value: 'running', label: 'running' },
+  { value: 'scaling', label: 'scaling' },
+  { value: 'degraded', label: 'degraded' },
+  { value: 'stopped', label: 'stopped' },
+] as const
+type StatusFilter = (typeof statusFilters)[number]['value']
+
+/** Ascending status sort reads problems-first: the reader clicking it is
+ * looking for what is wrong, not for the alphabet. */
+const statusRank: Record<string, number> = { degraded: 0, scaling: 1, running: 2, stopped: 3 }
+
+type SortKey = 'service' | 'status' | 'allocs'
 
 /** Services lists what is declared and how much of it is actually running. */
 export function Services() {
   const services = useLiveTopic({ topic: Topic.Services }, servicesResponseSchema)
   const allocs = useLiveTopic({ topic: Topic.Allocs }, allocsResponseSchema)
+  const [query, setQuery] = useState('')
+  const [status, setStatus] = useState<StatusFilter>('all')
+  const sort = useSort<SortKey>()
 
   // Functions are services underneath (v1.39) but have a page of their own —
   // one record, shown as what it is, on exactly one list.
   const list = (services.data?.services ?? []).filter((s) => s.function == null)
   const byService = groupAllocs(allocs.data?.allocs ?? [])
-  const pager = usePagination(list)
+
+  // Status is computed once per service, up here, because filtering and
+  // sorting need it before any row renders. The stats columns (CPU, mem, RPS,
+  // P95) are deliberately not sortable: each row holds its own bounded stats
+  // subscription, so the page never has those numbers to sort by.
+  const rows = list.map((svc) => {
+    const svcAllocs = byService.get(`${svc.Project}/${svc.Service}`) ?? []
+    return { svc, allocs: svcAllocs, status: serviceStatusTone(serviceHealth(svc, svcAllocs)) }
+  })
+  const filtered = rows.filter(
+    (row) =>
+      (status === 'all' || row.status.word === status) &&
+      matchesQuery(query, `${row.svc.Project}/${row.svc.Service}`, row.svc.Image),
+  )
+  const sorted = sortItems(filtered, sort, {
+    service: (row) => `${row.svc.Project}/${row.svc.Service}`,
+    status: (row) => statusRank[row.status.word],
+    allocs: (row) => row.allocs.filter((a) => a.state === 'running').length,
+  })
+  const pager = usePagination(sorted, {
+    resetKey: `${query} ${status} ${sort.key ?? ''} ${sort.dir}`,
+  })
 
   const allocCount = allocs.data?.allocs?.length ?? 0
 
@@ -59,42 +105,78 @@ export function Services() {
       ) : list.length === 0 ? (
         <Card className="p-4 text-sm text-muted-foreground">Nothing deployed yet.</Card>
       ) : (
-        <Card className="py-2">
-          <Table>
-            <THead>
-              <tr>
-                <TH className="pt-2">Service</TH>
-                <TH className="pt-2">Status</TH>
-                <TH className="pt-2">Allocs</TH>
-                <TH className="pt-2">CPU</TH>
-                <TH className="pt-2">Mem</TH>
-                <TH className="pt-2">RPS</TH>
-                <TH className="pt-2">P95</TH>
-                <TH className="pt-2">Autoscale</TH>
-              </tr>
-            </THead>
-            <TBody>
-              {pager.pageItems.map((svc) => (
-                <ServiceRow
-                  key={`${svc.Project}/${svc.Service}`}
-                  service={svc}
-                  allocs={byService.get(`${svc.Project}/${svc.Service}`) ?? []}
-                />
-              ))}
-            </TBody>
-          </Table>
-          <div className="px-3">
-            <PaginationControls state={pager} />
+        <>
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <FilterChips options={statusFilters} value={status} onChange={setStatus} />
+            <Input
+              type="search"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search name or image…"
+              aria-label="Search services"
+              className="h-8 w-56 text-xs"
+            />
           </div>
-        </Card>
+
+          {sorted.length === 0 ? (
+            // Distinct from "nothing deployed": services exist, the filter
+            // hides all of them, and only one of those is fixed by deploying.
+            <Card className="p-4 text-sm text-muted-foreground">
+              No services match that filter.
+            </Card>
+          ) : (
+            <Card className="py-2">
+              <Table>
+                <THead>
+                  <tr>
+                    <SortHeader sort={sort} sortKey="service" className="pt-2">
+                      Service
+                    </SortHeader>
+                    <SortHeader sort={sort} sortKey="status" className="pt-2">
+                      Status
+                    </SortHeader>
+                    <SortHeader sort={sort} sortKey="allocs" className="pt-2">
+                      Allocs
+                    </SortHeader>
+                    <TH className="pt-2">CPU</TH>
+                    <TH className="pt-2">Mem</TH>
+                    <TH className="pt-2">RPS</TH>
+                    <TH className="pt-2">P95</TH>
+                    <TH className="pt-2">Autoscale</TH>
+                  </tr>
+                </THead>
+                <TBody>
+                  {pager.pageItems.map((row) => (
+                    <ServiceRow
+                      key={`${row.svc.Project}/${row.svc.Service}`}
+                      service={row.svc}
+                      allocs={row.allocs}
+                      status={row.status}
+                    />
+                  ))}
+                </TBody>
+              </Table>
+              <div className="px-3">
+                <PaginationControls state={pager} />
+              </div>
+            </Card>
+          )}
+        </>
       )}
     </div>
   )
 }
 
-function ServiceRow({ service, allocs }: { service: Service; allocs: Alloc[] }) {
+function ServiceRow({
+  service,
+  allocs,
+  status,
+}: {
+  service: Service
+  allocs: Alloc[]
+  status: ReturnType<typeof serviceStatusTone>
+}) {
   const running = allocs.filter((a) => a.state === 'running').length
-  const status = serviceStatusTone(serviceHealth(service, allocs))
   const metrics = service.Scaling?.metrics ?? []
 
   return (


### PR DESCRIPTION
## What

Adds search, sortable columns and status filter chips to the dashboard's list pages:

- **Services** — search over name and image; chips for running / scaling / degraded / stopped; sortable Service, Status and Allocs columns (status sorts problems-first, not alphabetically).
- **Pipelines** — search over repo, ref, commit and trigger; state chips labelled the way the pills read (building / queued / ok / failed / cancelled); sortable Repository, Status and Duration.
- **Functions** — search over name and module; chips for active / idle / trapping / stopped; sortable Function, Inv/min, Mem cap and Status. The stat tiles keep summarising the full list, so "Active 3/9" can't become "3/3" under a filter.
- **Events** — free-text search over message, detail and source, beside the existing severity chips and scope glob; the chips now use the shared component.

## Shared pieces

- `useSort` + `sortItems`: header cycle asc → desc → back to the server's own order; **"no data" sorts last in both directions** — a dash is not a small number, per the dashboard's "no data is never zero" rule.
- `SortHeader`: clickable header with chevron affordance and `aria-sort`.
- `FilterChips`: the Events chip row, generalised so four pages don't grow four chip rows.
- `matchesQuery`: one case-insensitive substring search behaviour everywhere.

## Deliberate limits

- The per-row live stats columns (CPU, mem, RPS, P95) are **not** sortable: each row holds its own bounded stats subscription, so the page never has those numbers to sort by. A comment in the code says so.
- Filter/sort changes reset pagination (page 3 of "all" and page 3 of "error" are unrelated places), and "no services match that filter" stays distinct from "nothing deployed yet".

## Tests

`useSort` (cycle, undefined-last both directions, stability) and `matchesQuery` are unit-tested; dashboard gates green (lint, typecheck, 107 tests, build, audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)