### PR TITLE
security(dashboard): harden the console — CSRF, timeouts, CSP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ bpf-verify: ## Regenerate BPF artifacts and diff — CI gate (requires docker)
 .PHONY: dashboard
 dashboard: ## Dashboard gates: lint, typecheck, test, build, audit
 	@if [ -f dashboard/package.json ]; then \
-		cd dashboard && npm ci && npm run lint && npm run typecheck && npm test && npm run build && npm audit --audit-level=high; \
+		cd dashboard && npm ci && npm run lint && npm run typecheck && npm run test:coverage && npm run build && npm audit --audit-level=high; \
 	else \
 		echo "dashboard/ not scaffolded yet (milestone M4) — skipping"; \
 	fi

--- a/dashboard/.gitignore
+++ b/dashboard/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 *.local
+coverage/

--- a/dashboard/eslint.config.js
+++ b/dashboard/eslint.config.js
@@ -5,7 +5,7 @@ import reactRefresh from 'eslint-plugin-react-refresh'
 import tseslint from 'typescript-eslint'
 
 export default tseslint.config(
-  { ignores: ['dist', '../internal/dashboard/dist'] },
+  { ignores: ['dist', 'coverage', '../internal/dashboard/dist'] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommendedTypeChecked],
     files: ['**/*.{ts,tsx}'],

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -9,7 +9,8 @@
     "preview": "vite preview",
     "lint": "eslint .",
     "typecheck": "tsc -b --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.62.0",

--- a/dashboard/src/lib/api.test.ts
+++ b/dashboard/src/lib/api.test.ts
@@ -1,5 +1,15 @@
-import { describe, expect, it } from 'vitest'
-import { allocsResponseSchema, servicesResponseSchema, subscriptionKey, Topic } from './api'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  allocsResponseSchema,
+  createBackup,
+  servicesResponseSchema,
+  subscriptionKey,
+  syncProject,
+  Topic,
+  triggerBuild,
+  verifyBackup,
+} from './api'
+import { csrfHeader } from './session'
 
 describe('subscriptionKey', () => {
   it('is the bare topic when nothing scopes it', () => {
@@ -63,5 +73,67 @@ describe('allocsResponseSchema', () => {
       allocs: [{ ID: 'x', Project: 'shop', Service: 'web', Index: 0, State: 'running' }],
     })
     expect(result.success).toBe(false)
+  })
+})
+
+/** stubFetch records what was sent and answers with a fixed response. */
+function stubFetch(status: number, body: unknown = {}) {
+  const calls: { url: string; init: RequestInit | undefined }[] = []
+  vi.stubGlobal(
+    'fetch',
+    vi.fn((url: string | URL | Request, init?: RequestInit) => {
+      calls.push({ url: typeof url === 'string' ? url : url instanceof URL ? url.href : url.url, init })
+      return Promise.resolve({
+        ok: status >= 200 && status < 300,
+        status,
+        json: () => Promise.resolve(body),
+      } as Response)
+    }),
+  )
+  return calls
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+// The daemon checks the double-submit token on every cookie-authenticated
+// mutation (§13.3), so each mutating helper must route through apiFetch with
+// its token. These pin the wire shape a missing token would silently break.
+describe('mutations carry the CSRF token', () => {
+  it('triggerBuild posts with the header', async () => {
+    const calls = stubFetch(200, {
+      id: 'run-1', project: 'shop', service: 'web', state: 'queued',
+      trigger: 'manual', started_at: '2026-08-11T00:00:00Z',
+    })
+    await triggerBuild('shop', 'web', true, 'token-value')
+    const headers = calls[0]?.init?.headers as Record<string, string>
+    expect(calls[0]?.init?.method).toBe('POST')
+    expect(headers[csrfHeader]).toBe('token-value')
+  })
+
+  it('syncProject posts with the header', async () => {
+    const calls = stubFetch(204)
+    await syncProject('shop', 'token-value')
+    const headers = calls[0]?.init?.headers as Record<string, string>
+    expect(calls[0]?.init?.method).toBe('POST')
+    expect(headers[csrfHeader]).toBe('token-value')
+  })
+
+  it('createBackup posts with the header', async () => {
+    const calls = stubFetch(204)
+    await createBackup('from the dashboard', 'token-value')
+    const headers = calls[0]?.init?.headers as Record<string, string>
+    expect(calls[0]?.init?.method).toBe('POST')
+    expect(headers[csrfHeader]).toBe('token-value')
+  })
+
+  // verify is a GET at the daemon, and reads carry no token.
+  it('verifyBackup reads without the header', async () => {
+    const calls = stubFetch(204)
+    await verifyBackup('arch-1')
+    const headers = (calls[0]?.init?.headers ?? {}) as Record<string, string>
+    expect(calls[0]?.init?.method ?? 'GET').toBe('GET')
+    expect(headers[csrfHeader]).toBeUndefined()
   })
 })

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -377,13 +377,13 @@ export async function triggerBuild(
   project: string,
   service: string,
   deploy: boolean,
+  csrf?: string,
 ): Promise<Run> {
-  const resp = await fetch(`/v1/pipelines/${enc(project)}/${enc(service)}/build`, {
+  const resp = await apiFetch(`/v1/pipelines/${enc(project)}/${enc(service)}/build`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ deploy }),
+    body: { deploy },
+    ...(csrf ? { csrf } : {}),
   })
-  if (!resp.ok) throw new Error(await refusalText(resp, 'build'))
   return runSchema.parse(await resp.json())
 }
 
@@ -419,28 +419,11 @@ export async function restartService(project: string, service: string, csrf?: st
 }
 
 /** Sync a project's git source. */
-export async function syncProject(project: string): Promise<void> {
-  const resp = await fetch(`/v1/projects/${enc(project)}/sync`, { method: 'POST' })
-  if (!resp.ok) throw new Error(await refusalText(resp, 'sync'))
-}
-
-/**
- * refusalText turns a refusal into something an operator can act on.
- *
- * The daemon's message says which of several conditions failed — no build
- * block, no git source, queue full — and a bare status code says none of it.
- */
-async function refusalText(resp: Response, what: string): Promise<string> {
-  try {
-    const body: unknown = await resp.json()
-    if (body && typeof body === 'object' && 'error' in body) {
-      const message = body.error
-      if (typeof message === 'string' && message) return message
-    }
-  } catch {
-    // Not JSON. The status is all there is.
-  }
-  return `${what}: ${resp.status}`
+export async function syncProject(project: string, csrf?: string): Promise<void> {
+  await apiFetch(`/v1/projects/${enc(project)}/sync`, {
+    method: 'POST',
+    ...(csrf ? { csrf } : {}),
+  })
 }
 
 /** enc escapes one path segment. Names are DNS-1123, but URLs are URLs. */
@@ -707,19 +690,18 @@ export async function fetchBackups(signal?: AbortSignal): Promise<BackupsRespons
 }
 
 /** Take an on-demand archive. */
-export async function createBackup(reason: string): Promise<void> {
-  const resp = await fetch('/v1/backups', {
+export async function createBackup(reason: string, csrf?: string): Promise<void> {
+  await apiFetch('/v1/backups', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ reason }),
+    body: { reason },
+    ...(csrf ? { csrf } : {}),
   })
-  if (!resp.ok) throw new Error(await refusalText(resp, 'backup'))
 }
 
-/** Check an archive against its manifest. */
+/** Check an archive against its manifest. A read, so no CSRF — the daemon
+ * only checks the token on mutations. */
 export async function verifyBackup(id: string): Promise<void> {
-  const resp = await fetch(`/v1/backups/${enc(id)}/verify`)
-  if (!resp.ok) throw new Error(await refusalText(resp, 'verify'))
+  await apiFetch(`/v1/backups/${enc(id)}/verify`)
 }
 
 export const stageRestoreResponseSchema = z.object({

--- a/dashboard/src/lib/session.ts
+++ b/dashboard/src/lib/session.ts
@@ -45,6 +45,13 @@ export class ApiError extends Error {
 /** unauthorizedEvent is broadcast when any request is refused. */
 export const unauthorizedEvent = 'kanea:unauthorized'
 
+/**
+ * requestTimeout bounds every request. A hung daemon must show as a failed
+ * button, not a spinner that never resolves; callers that pass their own
+ * signal keep full control instead.
+ */
+export const requestTimeout = 30_000
+
 const errorSchema = z.object({ error: z.string() })
 
 /**
@@ -72,7 +79,9 @@ export async function apiFetch(
     credentials: 'same-origin',
   }
   if (opts.body !== undefined) init.body = JSON.stringify(opts.body)
-  if (opts.signal) init.signal = opts.signal
+  // A caller signal wins; everything else gets the standing timeout so no
+  // request can hang past it.
+  init.signal = opts.signal ?? AbortSignal.timeout(requestTimeout)
 
   const resp = await fetch(path, init)
   if (resp.status === 401) {
@@ -114,6 +123,7 @@ export async function login(user: string, password: string): Promise<Session> {
     headers: { 'Content-Type': 'application/json' },
     credentials: 'same-origin',
     body: JSON.stringify({ user, password }),
+    signal: AbortSignal.timeout(requestTimeout),
   })
   if (resp.status === 401) throw new ApiError(401, 'wrong user name or password')
   if (resp.status === 429) {

--- a/dashboard/src/lib/spec.ts
+++ b/dashboard/src/lib/spec.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { apiFetch } from './session'
+import { apiFetch, csrfHeader, requestTimeout } from './session'
 
 /**
  * The spec editor's wire surface (PRD §12.2, v1.38).
@@ -81,9 +81,10 @@ export async function applySpec(
     credentials: 'same-origin',
     headers: {
       'Content-Type': 'application/json',
-      ...(csrf ? { 'X-Kanea-CSRF': csrf } : {}),
+      ...(csrf ? { [csrfHeader]: csrf } : {}),
     },
     body: JSON.stringify({ files: { 'editor.hcl': hcl }, ...(project ? { project } : {}) }),
+    signal: AbortSignal.timeout(requestTimeout),
   })
   if (resp.status === 422) {
     const body = renderResponseSchema.parse(await resp.json())
@@ -112,7 +113,7 @@ export async function fetchSpecSource(
   service: string,
   signal?: AbortSignal,
 ): Promise<{ hcl: string } | { refusal: string }> {
-  const init: RequestInit = signal ? { signal } : {}
+  const init: RequestInit = signal ? { signal } : { signal: AbortSignal.timeout(requestTimeout) }
   const resp = await fetch(
     `/v1/spec/source?project=${encodeURIComponent(project)}&service=${encodeURIComponent(service)}`,
     init,

--- a/dashboard/src/pages/Backups.tsx
+++ b/dashboard/src/pages/Backups.tsx
@@ -53,7 +53,7 @@ export function Backups() {
   })
 
   const take = useMutation({
-    mutationFn: () => createBackup('from the dashboard'),
+    mutationFn: () => createBackup('from the dashboard', csrf),
     onSuccess: () => {
       setError('')
       void client.invalidateQueries({ queryKey: ['backups'] })

--- a/dashboard/src/pages/Login.tsx
+++ b/dashboard/src/pages/Login.tsx
@@ -22,6 +22,10 @@ export function Login() {
   // credential — including which sign-in methods exist.
   const health = useQuery({ queryKey: ['health'], queryFn: ({ signal }) => fetchHealth(signal) })
   const provider = health.data?.oidc?.enabled ? health.data.oidc : null
+  // The daemon supplies the SSO entry point; only a path on its own origin is
+  // ever rendered as a link. Anything else — an absolute URL, a javascript:
+  // scheme — is a misconfiguration to ignore, not navigate to.
+  const ssoPath = provider?.start_path?.startsWith('/') ? provider.start_path : null
   const [user, setUser] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState<string | null>(null)
@@ -94,7 +98,7 @@ export function Login() {
             </Button>
           </form>
 
-          {provider?.start_path ? (
+          {ssoPath ? (
             <div className="mt-4 space-y-4">
               <div className="flex items-center gap-3">
                 <span aria-hidden className="h-px flex-1 bg-border" />
@@ -105,13 +109,13 @@ export function Login() {
                   redirect to its own login page, which only the browser can
                   follow. The daemon sets the handle cookie on the way out. */}
               <a
-                href={provider.start_path}
+                href={ssoPath}
                 className="flex h-9 w-full items-center justify-center gap-2 rounded-md border text-sm font-medium transition-colors hover:bg-muted"
               >
                 <Globe size={15} aria-hidden />
                 Continue with SSO
               </a>
-              <p className="text-center text-xs text-muted-foreground">{issuerHost(provider.issuer)}</p>
+              <p className="text-center text-xs text-muted-foreground">{issuerHost(provider?.issuer)}</p>
             </div>
           ) : null}
         </CardContent>

--- a/dashboard/src/pages/PipelineDetail.tsx
+++ b/dashboard/src/pages/PipelineDetail.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -196,12 +197,16 @@ function stepTone(state: string): StatusTone {
   }
 }
 
-/** DownloadRaw hands the fetched log over as a file, no extra endpoint. */
+/** DownloadRaw hands the fetched log over as a file, no extra endpoint. A
+ * blob URL rather than a data: URI — it stays valid under a strict CSP and
+ * does not grow the DOM attribute with the whole log. */
 function DownloadRaw({ text }: { text: string }) {
+  const url = useMemo(() => URL.createObjectURL(new Blob([text], { type: 'text/plain' })), [text])
+  useEffect(() => () => URL.revokeObjectURL(url), [url])
   return (
     <a
       download="build.log"
-      href={`data:text/plain;charset=utf-8,${encodeURIComponent(text)}`}
+      href={url}
       className="text-xs font-medium text-primary hover:underline"
     >
       Download raw

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -29,5 +29,11 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
+    coverage: {
+      provider: 'v8',
+      // Ratchet, not aspiration: the floor is where the suite stands today,
+      // and it should be raised whenever a page gains tests.
+      thresholds: { statements: 48, branches: 29, functions: 35, lines: 50 },
+    },
   },
 })

--- a/internal/dashboard/dashboard.go
+++ b/internal/dashboard/dashboard.go
@@ -68,6 +68,10 @@ func Handler(prefix string) http.Handler {
 	server := http.FileServer(http.FS(files))
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Every answer carries these — the 200s, the 404s and the 405 alike —
+		// because the headers protect the origin, not one page on it.
+		setSecurityHeaders(w, r)
+
 		// Registered on the bare prefix so the API's own patterns stay more
 		// specific, which means the method check lands here rather than in the
 		// route pattern. Static assets answer GET and HEAD and nothing else.
@@ -139,4 +143,42 @@ func serveIndex(w http.ResponseWriter, r *http.Request, files fs.FS) {
 // `/assets/index-abc.js` is not.
 func looksLikeAsset(name string) bool {
 	return path.Ext(name) != ""
+}
+
+// contentSecurityPolicy is the depth layer under the app's own discipline.
+//
+// The dashboard renders attacker-influenced strings — log lines, service
+// names, event messages — and React escapes all of them; the ESLint ban on
+// dangerouslySetInnerHTML keeps it that way. This policy is what stops a
+// future slip from becoming an exploit: no inline script or style exists in
+// the build (Vite emits files, and only files), the one data: URI is the
+// favicon, and the only connections the app makes are to its own origin —
+// REST and the live socket, which CSP3's 'self' covers for ws/wss too.
+// frame-ancestors is the clickjacking guard: an admin console with stop,
+// restart and restore buttons is exactly what an invisible overlay wants.
+const contentSecurityPolicy = "default-src 'self'; " +
+	"script-src 'self'; style-src 'self'; " +
+	"img-src 'self' data:; font-src 'self'; " +
+	"connect-src 'self'; frame-src 'none'; " +
+	"frame-ancestors 'none'; base-uri 'self'; " +
+	"form-action 'self'; object-src 'none'"
+
+// setSecurityHeaders writes the browser-side hardening for one response.
+func setSecurityHeaders(w http.ResponseWriter, r *http.Request) {
+	h := w.Header()
+	h.Set("Content-Security-Policy", contentSecurityPolicy)
+	// A 404 from here is plain text; nosniff keeps a browser from reading it
+	// as something else.
+	h.Set("X-Content-Type-Options", "nosniff")
+	// The modern spelling is frame-ancestors above; this is the one older
+	// browsers still read.
+	h.Set("X-Frame-Options", "DENY")
+	// The app never navigates away with a secret in the URL, and a referrer
+	// would leak a session's path to whatever is embedded or linked.
+	h.Set("Referrer-Policy", "no-referrer")
+	// Browsers ignore it over plain HTTP, and a homelab node behind its own
+	// proxy may legitimately serve HTTP — so it is only claimed under TLS.
+	if r.TLS != nil {
+		h.Set("Strict-Transport-Security", "max-age=31536000")
+	}
 }

--- a/internal/dashboard/dashboard_test.go
+++ b/internal/dashboard/dashboard_test.go
@@ -2,6 +2,7 @@ package dashboard_test
 
 import (
 	"context"
+	"crypto/tls"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -116,5 +117,71 @@ func TestBuiltReportsWhetherAssetsArePresent(t *testing.T) {
 	isPlaceholder := strings.Contains(text, "was not built into this binary")
 	if built == isPlaceholder {
 		t.Errorf("Built() = %v but the served page is the placeholder = %v", built, isPlaceholder)
+	}
+}
+
+// The security headers protect the origin, not one page, so every answer
+// carries them — the 200, the 404 and the 405 alike.
+func TestSecurityHeaders(t *testing.T) {
+	h := dashboard.Handler("/")
+
+	cases := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodGet, "/"},
+		{http.MethodGet, "/services"},
+		{http.MethodGet, "/assets/index-deadbeef.js"}, // a 404
+		{http.MethodPost, "/"},                        // a 405
+	}
+	for _, tc := range cases {
+		req := httptest.NewRequestWithContext(context.Background(), tc.method, tc.path, nil)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		resp := w.Result()
+		_ = body(t, resp)
+
+		for header, want := range map[string]string{
+			"X-Content-Type-Options": "nosniff",
+			"X-Frame-Options":        "DENY",
+			"Referrer-Policy":        "no-referrer",
+		} {
+			if got := resp.Header.Get(header); got != want {
+				t.Errorf("%s %s: %s = %q, want %q", tc.method, tc.path, header, got, want)
+			}
+		}
+
+		csp := resp.Header.Get("Content-Security-Policy")
+		for _, directive := range []string{
+			"default-src 'self'",
+			"script-src 'self'",
+			"frame-ancestors 'none'",
+		} {
+			if !strings.Contains(csp, directive) {
+				t.Errorf("%s %s: CSP missing %q: %q", tc.method, tc.path, directive, csp)
+			}
+		}
+	}
+}
+
+// HSTS is only claimed under TLS: browsers ignore it over plain HTTP, and a
+// node behind its own proxy may legitimately serve HTTP.
+func TestHSTSRequiresTLS(t *testing.T) {
+	h := dashboard.Handler("/")
+
+	plain := get(t, h, "/")
+	_ = body(t, plain)
+	if got := plain.Header.Get("Strict-Transport-Security"); got != "" {
+		t.Errorf("HSTS over plain HTTP = %q, want none", got)
+	}
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req.TLS = &tls.ConnectionState{} // any TLS state: the fact of it is the point
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	resp := w.Result()
+	_ = body(t, resp)
+	if got := resp.Header.Get("Strict-Transport-Security"); got == "" {
+		t.Error("no HSTS under TLS")
 	}
 }


### PR DESCRIPTION
## What & why

Security review of the dashboard found the console's own request layer inconsistent with the daemon's auth model, and the serving path shipping no browser-side hardening at all. One logical change: close both.

**Dashboard (`dashboard/`)**
- `triggerBuild`, `syncProject`, `createBackup` posted without the double-submit token the daemon enforces on every cookie-authenticated mutation (§13.3) — latent 403s. They now route through `apiFetch` with the token, like scale/restart/restore. `verifyBackup` is a GET at the daemon (`server.go`) and stays one.
- Every request gains a 30 s timeout (`AbortSignal.timeout`; caller signals still win) so a hung daemon shows as a failed button, not a stuck spinner.
- The OIDC `start_path` is only rendered as a link when it is a path on the daemon's own origin; absolute/`javascript:` values from a misconfigured issuer are ignored.
- Build-log download is a blob URL instead of a `data:` URI (CSP-safe, no whole-log DOM attribute).
- `applySpec` uses the exported `csrfHeader` constant instead of a hardcoded string.

**Serving (`internal/dashboard`)**
- Every response — 200, 404 and 405 alike — now carries a strict CSP (all `'self'`, no inline script or style, `data:` only for the favicon, `frame-ancestors 'none'` against clickjacking of the destructive buttons), `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy: no-referrer`; HSTS is claimed only under TLS (browsers ignore it over plain HTTP, and a node behind its own proxy may legitimately serve HTTP).

**Gates**
- Four new tests pin the CSRF wire shape; header tests cover 200/deep-link/404/405 and the TLS-only HSTS rule.
- A v8 coverage ratchet (48/29/35/50 — today's floor) is wired into `make dashboard` via a new `test:coverage` script.

Verified locally: dashboard lint, typecheck, 111/111 tests, build (105.7 kB gzip, under the §21 budget), `npm audit` clean; `go vet` + tests for `internal/dashboard`; full binary builds. `golangci-lint`/`gosec`/`gitleaks` are not installed on this machine — CI runs them.

## Checklist

- [x] This change follows `PRD.md` — or the PRD was amended first in this PR (AGENTS.md constraint #1)
- [ ] `make check` passes locally (vet, test, lint, security gates)
- [x] No secrets/credentials added (gitleaks-clean); secrets are `secret:`-referenced, never inlined
- [x] Metrics/logs did not touch the Store; mutations go through `Store` with monotonic indexes
- [x] New API/WS/MCP routes are deny-by-default behind auth middleware
- [x] Tests added/updated (table-driven; reconciler & jobspec >80% coverage)
- [x] Docs updated (`PRD.md`, `AGENTS.md`, `docs/`) where behavior changed