### PR TITLE
fix(api): annotate the deliberate 0660 socket mode for gosec

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -610,6 +610,10 @@ func (s *Server) applySocketGroup(gid int) error {
 	if err := os.Chown(s.socket, -1, gid); err != nil {
 		return fmt.Errorf("chgrp socket: %w", err)
 	}
+	// #nosec G302 — 0660 is the feature: a unix socket needs the group write
+	// bit for connect(2), and granting the operator-created kanea group the
+	// socket is exactly what PRD v1.48 specifies. Root-only was set first, so
+	// failing here leaves 0600.
 	return os.Chmod(s.socket, 0o660)
 }
 


### PR DESCRIPTION
Follow-up to #37, which merged one commit early: both the lint and security gates flag the group-writable socket as G302, and the annotation explaining why 0660 is the feature (the group write bit is what connect(2) needs; root-only is set first, so a failure widening leaves 0600) was still on the branch. Main is red until this lands, and the v0.6.0 tag waits on it — release.yml runs make check first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)