### PR TITLE
fix(agent): kanead crash-looped at startup — pipeline runner never given its checkout directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Prefer to do it by hand? Every release publishes
 signature over the checksums:
 
 ```bash
-VERSION=v0.7.0; ARCH=amd64
+VERSION=v0.7.1; ARCH=amd64
 BASE=https://github.com/m18h/kanea/releases/download/$VERSION
 
 curl -fLO $BASE/kanea_${VERSION#v}_linux_$ARCH.tar.gz

--- a/cmd/kanea/pipelines.go
+++ b/cmd/kanea/pipelines.go
@@ -99,7 +99,15 @@ func buildPipelines(cfg pipelineSettings, logger *slog.Logger) (*gitops.Service,
 		Deployer: storeDeployer{store: cfg.store, notify: cfg.notify, log: logger},
 		Secrets:  cfg.secrets,
 		LogDir:   cfg.logDir,
-		Logger:   logger,
+		// Checkouts are materialised beside the build logs — the one directory
+		// §10.2 already gives the right permissions — under their own name.
+		// This field was never set until v0.7.1: NewRunner refuses without it,
+		// so kanead with pipelines enabled (the default) crash-looped on every
+		// real node. Only unit tests ever built a RunnerConfig, and they all
+		// passed their own WorkDir — TestBuildPipelinesStartsWithDefaults now
+		// walks this wiring instead.
+		WorkDir: filepath.Join(cfg.logDir, "checkouts"),
+		Logger:  logger,
 	})
 	if err != nil {
 		return nil, nil, err

--- a/cmd/kanea/pipelines_test.go
+++ b/cmd/kanea/pipelines_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"log/slog"
+	"path/filepath"
+	"testing"
+
+	"github.com/m18h/kanea/internal/store"
+)
+
+// The daemon's own pipeline wiring must construct — not just the gitops
+// package's pieces individually. RunnerConfig.WorkDir was required from the
+// day the runner landed and this call site never set it, so kanead with
+// pipelines enabled (the default) refused to start on every real node while
+// every unit test, building its own RunnerConfig, passed. This walks the
+// wiring the daemon actually runs.
+func TestBuildPipelinesStartsWithDefaults(t *testing.T) {
+	st, err := store.Open(store.Options{Path: filepath.Join(t.TempDir(), "state.db")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+
+	svc, queue, err := buildPipelines(pipelineSettings{
+		buildkit: "unix:///run/does-not-need-to-exist/buildkitd.sock",
+		logDir:   filepath.Join(t.TempDir(), "builds"),
+		store:    st,
+	}, slog.New(slog.DiscardHandler))
+	if err != nil {
+		t.Fatalf("buildPipelines with default-shaped settings refused: %v", err)
+	}
+	if svc == nil || queue == nil {
+		t.Fatal("buildPipelines returned a nil service or queue with pipelines enabled")
+	}
+
+	// And "off" stays a supported configuration: nil everything, no error.
+	svc, queue, err = buildPipelines(pipelineSettings{buildkit: "off"}, slog.New(slog.DiscardHandler))
+	if err != nil || svc != nil || queue != nil {
+		t.Fatalf("buildkit=off = (%v, %v, %v), want (nil, nil, nil)", svc, queue, err)
+	}
+}

--- a/site/index.html
+++ b/site/index.html
@@ -320,7 +320,7 @@ kanea ui</pre>
       </p>
       <div class="window">
         <div class="bar"><i></i><i></i><i></i><span>manual install</span></div>
-<pre>VERSION=v0.7.0; ARCH=amd64
+<pre>VERSION=v0.7.1; ARCH=amd64
 BASE=https://github.com/m18h/kanea/releases/download/$VERSION
 
 curl -fLO $BASE/kanea_${VERSION#v}_linux_$ARCH.tar.gz


### PR DESCRIPTION
`RunnerConfig.WorkDir` has been required since the runner landed in M7, and the daemon's `buildPipelines` wiring never set it — kanead with pipelines enabled (the default) printed `gitops: a checkout directory is required` and exited 1 on every start. Found on a real Debian 12 node with the systemd restart counter at 2169; it is also why `kanea init`'s wait-for-daemon timed out on that node.

Every unit test passed because each constructs its own `RunnerConfig` with its own `WorkDir`; the daemon's call site was never walked. The fix sets `WorkDir` beside the build logs (`<build-log-dir>/checkouts` — the directory §10.2 already gives the right permissions), and `TestBuildPipelinesStartsWithDefaults` now exercises the daemon's own wiring, including the supported `buildkit = "off"` path.

Release as **v0.7.1** — the current release cannot start on a default install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)