### PR TITLE
docs: release prep for v0.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Prefer to do it by hand? Every release publishes
 signature over the checksums:
 
 ```bash
-VERSION=v0.11.0; ARCH=amd64
+VERSION=v0.12.0; ARCH=amd64
 BASE=https://github.com/m18h/kanea/releases/download/$VERSION
 
 curl -fLO $BASE/kanea_${VERSION#v}_linux_$ARCH.tar.gz
@@ -314,7 +314,7 @@ one place to update.
 
 | File | Content |
 |---|---|
-| [`PRD.md`](./PRD.md) | Product Requirements Document — the **north star** (v1.56) |
+| [`PRD.md`](./PRD.md) | Product Requirements Document — the **north star** (v1.58) |
 | [`AGENTS.md`](./AGENTS.md) | Conventions and binding constraints for contributors (human & AI) |
 | [`docs/THREAT_MODEL.md`](./docs/THREAT_MODEL.md) | Boundaries, adversaries, OWASP Top 10 as built |
 | [`docs/DR_RUNBOOK.md`](./docs/DR_RUNBOOK.md) | Disaster recovery — read it before you need it |

--- a/site/index.html
+++ b/site/index.html
@@ -198,7 +198,9 @@
       </div>
 
       <p class="note" style="margin-top:22px">
-        <code>kanea plan</code> gives you the diff before <code>kanea run</code> applies it.
+        <code>kanea plan</code> gives you the diff before <code>kanea run</code> applies it —
+        and both take selectors (<code>kanea run app.hcl shop/web</code>) to scope one
+        project or service out of a file.
         Secrets are referenced as <code>secret:&lt;path&gt;</code>, scoped to their own project
         at validation time, and injected as tmpfs files — a spec that reaches for another
         project's secret fails to parse, not at runtime.
@@ -321,7 +323,7 @@ kanea ui</pre>
       </p>
       <div class="window">
         <div class="bar"><i></i><i></i><i></i><span>manual install</span></div>
-<pre>VERSION=v0.11.0; ARCH=amd64
+<pre>VERSION=v0.12.0; ARCH=amd64
 BASE=https://github.com/m18h/kanea/releases/download/$VERSION
 
 curl -fLO $BASE/kanea_${VERSION#v}_linux_$ARCH.tar.gz


### PR DESCRIPTION
Pre-tag checklist for v0.12.0 (AGENTS.md Releases): bumps the manual-install `VERSION=` pins in `README.md` and `site/index.html` to the tag being cut, fixes the README documentation table's PRD reference (said v1.56, PRD is at v1.58), and adds the selector mention to the landing page's plan/run note. Everything else on the checklist landed with #46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)