### PR TITLE
docs: release prep for v0.13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Prefer to do it by hand? Every release publishes
 signature over the checksums:
 
 ```bash
-VERSION=v0.12.0; ARCH=amd64
+VERSION=v0.13.0; ARCH=amd64
 BASE=https://github.com/m18h/kanea/releases/download/$VERSION
 
 curl -fLO $BASE/kanea_${VERSION#v}_linux_$ARCH.tar.gz
@@ -314,7 +314,7 @@ one place to update.
 
 | File | Content |
 |---|---|
-| [`PRD.md`](./PRD.md) | Product Requirements Document — the **north star** (v1.58) |
+| [`PRD.md`](./PRD.md) | Product Requirements Document — the **north star** (v1.59) |
 | [`AGENTS.md`](./AGENTS.md) | Conventions and binding constraints for contributors (human & AI) |
 | [`docs/THREAT_MODEL.md`](./docs/THREAT_MODEL.md) | Boundaries, adversaries, OWASP Top 10 as built |
 | [`docs/DR_RUNBOOK.md`](./docs/DR_RUNBOOK.md) | Disaster recovery — read it before you need it |

--- a/site/index.html
+++ b/site/index.html
@@ -323,7 +323,7 @@ kanea ui</pre>
       </p>
       <div class="window">
         <div class="bar"><i></i><i></i><i></i><span>manual install</span></div>
-<pre>VERSION=v0.12.0; ARCH=amd64
+<pre>VERSION=v0.13.0; ARCH=amd64
 BASE=https://github.com/m18h/kanea/releases/download/$VERSION
 
 curl -fLO $BASE/kanea_${VERSION#v}_linux_$ARCH.tar.gz


### PR DESCRIPTION
Pre-tag checklist for v0.13.0: `VERSION=` pins in `README.md`/`site/index.html` move to the tag being cut, and the README documentation table catches up to PRD v1.59 (#48 landed after the v0.12.0 prep). The v0.12.0 tag stays where it is — never released, immutable by ruleset — and the release ships as v0.13.0 with all three amendments (v1.57–v1.59).

🤖 Generated with [Claude Code](https://claude.com/claude-code)