### PR TITLE
docs: release prep for v0.14.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Prefer to do it by hand? Every release publishes
 signature over the checksums:
 
 ```bash
-VERSION=v0.13.0; ARCH=amd64
+VERSION=v0.14.0; ARCH=amd64
 BASE=https://github.com/m18h/kanea/releases/download/$VERSION
 
 curl -fLO $BASE/kanea_${VERSION#v}_linux_$ARCH.tar.gz

--- a/site/index.html
+++ b/site/index.html
@@ -335,7 +335,7 @@ brew install kanea</pre>
       </p>
       <div class="window">
         <div class="bar"><i></i><i></i><i></i><span>manual install</span></div>
-<pre>VERSION=v0.13.0; ARCH=amd64
+<pre>VERSION=v0.14.0; ARCH=amd64
 BASE=https://github.com/m18h/kanea/releases/download/$VERSION
 
 curl -fLO $BASE/kanea_${VERSION#v}_linux_$ARCH.tar.gz


### PR DESCRIPTION
## What & why

Release checklist for v0.14.0: the manual-install `VERSION=` pins in `README.md` and `site/index.html` move to the tag being cut. Everything else on the checklist landed with #50 and #51 — docs describe what ships (Homebrew channel, the `bind` stanza with `api_tls` modes), PRD references name v1.61 in both README and AGENTS.md, and the amendment bullets are current.

## Checklist

- [x] This change follows `PRD.md` (docs only)
- [x] `make check` unaffected (no code)
- [x] No secrets/credentials added
- [x] Store untouched
- [x] No new routes
- [x] No tests needed (version pins in prose)
- [x] Docs updated — that is the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)