### PR TITLE
docs: the Homebrew quickstart needs brew trust

### DIFF
--- a/Formula/kanea.rb
+++ b/Formula/kanea.rb
@@ -3,6 +3,7 @@
 #
 # Install:
 #     brew tap m18h/kanea https://github.com/m18h/kanea
+#     brew trust m18h/kanea
 #     brew install kanea
 class Kanea < Formula
   desc "Container orchestration in one binary"

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ log.
 
 ```bash
 brew tap m18h/kanea https://github.com/m18h/kanea
+brew trust m18h/kanea   # brew ≥ 6 refuses formulae from untrusted third-party taps
 brew install kanea
 ```
 

--- a/scripts/update-formula.sh
+++ b/scripts/update-formula.sh
@@ -85,6 +85,7 @@ cat > "$OUT" <<EOF
 #
 # Install:
 #     brew tap ${REPO%%/*}/kanea https://github.com/${REPO}
+#     brew trust ${REPO%%/*}/kanea
 #     brew install kanea
 class Kanea < Formula
   desc "Container orchestration in one binary"

--- a/site/index.html
+++ b/site/index.html
@@ -326,6 +326,7 @@ kanea ui</pre>
         <em>node</em> belongs to the installer above.
       </p>
       <pre class="plain">brew tap m18h/kanea https://github.com/m18h/kanea
+brew trust m18h/kanea
 brew install kanea</pre>
 
       <h3 style="margin:38px 0 10px">Or install it by hand</h3>


### PR DESCRIPTION
## What & why

brew ≥ 6 refuses formulae from untrusted third-party taps, so the documented `brew tap` + `brew install` flow stops at an error. Found by installing the published v0.14.0 from the real tap on a Mac (the install and `brew test` pass once the tap is trusted). Adds `brew trust m18h/kanea` to the README and site quickstarts and to the generated formula's header comment.

## Checklist

- [x] Docs only; no code paths changed (the generator edit is a comment in its output)
- [x] Verified against the real published release on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)