### PR TITLE
feat: `kanea run` reports what is stuck, not just how many

### DIFF
--- a/cmd/kanea/client_cmds.go
+++ b/cmd/kanea/client_cmds.go
@@ -152,7 +152,10 @@ func runRun(args []string) error {
 }
 
 // waitForRunning polls until every desired alloc is running, so `kanea run`
-// exits meaning "it is up" rather than "it was requested".
+// exits meaning "it is up" rather than "it was requested". Progress is
+// reported as state transitions, and on failure or timeout the stragglers are
+// listed by name with the detail `kanea ps` would give — the answer the user
+// would otherwise have to go fetch.
 func waitForRunning(ctx context.Context, client *api.Client, desired []reconciler.Desired, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	want := 0
@@ -163,16 +166,23 @@ func waitForRunning(ctx context.Context, client *api.Client, desired []reconcile
 		return nil
 	}
 
+	o := newOut()
+	// The first poll is a silent baseline: a service that was already up must
+	// not re-announce itself on every converged re-apply.
+	last := map[string]reconciler.AllocState{}
+	seeded := false
 	for {
 		allocs, err := client.Allocs(ctx, "", "")
 		if err != nil {
 			return err
 		}
+		ours := allocs[:0]
 		running, failed := 0, 0
 		for _, a := range allocs {
 			if !isDesiredAlloc(desired, a) {
 				continue
 			}
+			ours = append(ours, a)
 			switch a.State {
 			case reconciler.AllocRunning:
 				running++
@@ -180,19 +190,65 @@ func waitForRunning(ctx context.Context, client *api.Client, desired []reconcile
 				failed++
 			}
 		}
+		for _, a := range ours {
+			if seeded && a.State != last[a.ID] {
+				switch a.State {
+				case reconciler.AllocRunning:
+					o.printf("%s running (%d/%d)\n", a.ID, running, want)
+				case reconciler.AllocBackoff, reconciler.AllocFailed:
+					o.printf("%s %s\n", a.ID, allocStateLabel(a))
+				}
+			}
+			last[a.ID] = a.State
+		}
+		seeded = true
 		if running >= want {
-			o := newOut()
 			o.printf("%d/%d allocs running\n", running, want)
 			return o.Err()
 		}
-		if failed > 0 {
-			return fmt.Errorf("%d alloc(s) failed; see `kanea logs` and `kanea ps`", failed)
-		}
-		if time.Now().After(deadline) {
-			return fmt.Errorf("timed out after %s with %d/%d allocs running; see `kanea ps`",
-				timeout, running, want)
+		if failed > 0 || time.Now().After(deadline) {
+			printStragglers(o, desired, ours)
+			if err := o.Err(); err != nil {
+				return err
+			}
+			if failed > 0 {
+				return fmt.Errorf("%d alloc(s) failed with %d/%d running", failed, running, want)
+			}
+			return fmt.Errorf("timed out after %s with %d/%d allocs running", timeout, running, want)
 		}
 		time.Sleep(250 * time.Millisecond)
+	}
+}
+
+// printStragglers lists every desired slot that is not up, with the state
+// detail `kanea ps` would show — including declared slots the reconciler has
+// not created yet, which have no record to explain themselves with.
+func printStragglers(o *out, desired []reconciler.Desired, allocs []reconciler.AllocRecord) {
+	byID := map[string]reconciler.AllocRecord{}
+	for _, a := range allocs {
+		byID[a.ID] = a
+	}
+	crashed := false
+	o.println("\nstill not running:")
+	o.table()
+	for _, d := range desired {
+		for i := 0; i < d.Count; i++ {
+			id := reconciler.AllocID(d.Project, d.Service, i)
+			a, ok := byID[id]
+			switch {
+			case !ok:
+				o.printf("  %s\tpending (not created)\n", id)
+			case a.State != reconciler.AllocRunning:
+				o.printf("  %s\t%s\n", id, allocStateLabel(a))
+				crashed = crashed || a.State == reconciler.AllocBackoff || a.State == reconciler.AllocFailed
+			case !a.Healthy && !a.LastProbeAt.IsZero():
+				o.printf("  %s\trunning (unhealthy)\n", id)
+			}
+		}
+	}
+	o.endTable()
+	if crashed {
+		o.println("`kanea logs <project>/<service>` shows the crash output")
 	}
 }
 
@@ -308,31 +364,35 @@ func runPs(args []string) error {
 		if !a.CreatedAt.IsZero() {
 			age = shortDuration(time.Since(a.CreatedAt))
 		}
-		state := string(a.State)
-		// A failed or backing-off alloc must explain itself here: `ps` is where
-		// a user looks first when something is not running.
-		switch a.State {
-		case reconciler.AllocFailed:
-			state = fmt.Sprintf("failed (exit %d)", a.LastExitCode)
-		case reconciler.AllocBackoff:
-			state = fmt.Sprintf("backoff (exit %d, retry in %s)",
-				a.LastExitCode, shortDuration(time.Until(a.NextRestartAt)))
-		case reconciler.AllocRunning:
-			// A running-but-failing alloc is the case `ps` most needs to
-			// distinguish: the process is up, so "running" alone is misleading,
-			// and it is why anything depending on it has not started.
-			if !a.Healthy && !a.LastProbeAt.IsZero() {
-				state = "running (unhealthy)"
-			}
-		}
 		o.printf("%s\t%s\t%s\t%s\t%d\t%s\t%s\n",
-			a.ID, a.Project, a.Service, state, a.Restarts, a.Image, age)
+			a.ID, a.Project, a.Service, allocStateLabel(a), a.Restarts, a.Image, age)
 	}
 	for _, g := range ghosts {
 		o.printf("%s\t%s\t%s\t%s\t-\t%s\t-\n",
 			g.id, g.project, g.service, g.state, g.image)
 	}
 	return o.Err()
+}
+
+// allocStateLabel renders an alloc's state with the detail a status line
+// needs: a failed or backing-off alloc must explain itself — `ps` and the
+// `run` wait are where a user looks first when something is not running —
+// and a running-but-failing alloc is the case that most needs distinguishing:
+// the process is up, so "running" alone is misleading, and it is why anything
+// depending on it has not started.
+func allocStateLabel(a reconciler.AllocRecord) string {
+	switch a.State {
+	case reconciler.AllocFailed:
+		return fmt.Sprintf("failed (exit %d)", a.LastExitCode)
+	case reconciler.AllocBackoff:
+		return fmt.Sprintf("backoff (exit %d, retry in %s)",
+			a.LastExitCode, shortDuration(time.Until(a.NextRestartAt)))
+	case reconciler.AllocRunning:
+		if !a.Healthy && !a.LastProbeAt.IsZero() {
+			return "running (unhealthy)"
+		}
+	}
+	return string(a.State)
 }
 
 // psGhost is a `ps -a` row for something declared with no alloc record.

--- a/cmd/kanea/run_wait_test.go
+++ b/cmd/kanea/run_wait_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/m18h/kanea/internal/reconciler"
+)
+
+func TestAllocStateLabelExplainsItself(t *testing.T) {
+	now := time.Now()
+	cases := []struct {
+		name  string
+		alloc reconciler.AllocRecord
+		want  string
+	}{
+		{
+			name:  "failed carries the exit code",
+			alloc: reconciler.AllocRecord{State: reconciler.AllocFailed, LastExitCode: 137},
+			want:  "failed (exit 137)",
+		},
+		{
+			name: "backoff carries exit code and retry",
+			alloc: reconciler.AllocRecord{
+				State: reconciler.AllocBackoff, LastExitCode: 1,
+				NextRestartAt: now.Add(2 * time.Second),
+			},
+			want: "backoff (exit 1",
+		},
+		{
+			name:  "running with no probe is just running",
+			alloc: reconciler.AllocRecord{State: reconciler.AllocRunning},
+			want:  "running",
+		},
+		{
+			name: "running but probed unhealthy says so",
+			alloc: reconciler.AllocRecord{
+				State: reconciler.AllocRunning, Healthy: false, LastProbeAt: now,
+			},
+			want: "running (unhealthy)",
+		},
+		{
+			name:  "pending passes through",
+			alloc: reconciler.AllocRecord{State: reconciler.AllocPending},
+			want:  "pending",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := allocStateLabel(tc.alloc)
+			if !strings.HasPrefix(got, tc.want) {
+				t.Fatalf("allocStateLabel = %q, want prefix %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// The straggler summary is the reason `kanea run` no longer ends with "see
+// `kanea ps`": everything ps would say about a slot that is not up has to be
+// in it, including declared slots that have no alloc record at all.
+func TestStragglerSummaryNamesEverySlotThatIsNotUp(t *testing.T) {
+	desired := []reconciler.Desired{
+		{Project: "media", Service: "watchstate", Count: 1},
+		{Project: "media", Service: "opds", Count: 1},
+		{Project: "media", Service: "jellyfin", Count: 1},
+		{Project: "media", Service: "navidrome", Count: 1},
+	}
+	allocs := []reconciler.AllocRecord{
+		{
+			ID:    reconciler.AllocID("media", "watchstate", 0),
+			State: reconciler.AllocBackoff, LastExitCode: 1,
+			NextRestartAt: time.Now().Add(time.Second),
+		},
+		{
+			ID:    reconciler.AllocID("media", "jellyfin", 0),
+			State: reconciler.AllocRunning,
+		},
+		{
+			ID:    reconciler.AllocID("media", "navidrome", 0),
+			State: reconciler.AllocRunning, Healthy: false, LastProbeAt: time.Now(),
+		},
+		// media-opds-0 has no record: the reconciler has not created it.
+	}
+
+	var buf strings.Builder
+	o := &out{w: &buf}
+	printStragglers(o, desired, allocs)
+	if err := o.Err(); err != nil {
+		t.Fatalf("printStragglers: %v", err)
+	}
+	got := buf.String()
+
+	for _, want := range []string{
+		"media-watchstate-0", "backoff (exit 1",
+		"media-opds-0", "pending (not created)",
+		"media-navidrome-0", "running (unhealthy)",
+		"kanea logs",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("summary is missing %q:\n%s", want, got)
+		}
+	}
+	// A slot that is up and healthy is not a straggler.
+	if strings.Contains(got, "media-jellyfin-0") {
+		t.Errorf("summary lists a healthy running alloc:\n%s", got)
+	}
+}


### PR DESCRIPTION
## What

`kanea run`'s post-apply wait now reports per-alloc progress and, on timeout or failure, lists every straggler by name with `ps`-style detail — instead of ending with a bare count and "see `kanea ps`".

- Live transition lines during the wait: an alloc reaching `running` prints with a progress counter; an alloc entering `backoff`/`failed` prints with its exit code. The first poll is a silent baseline, so a converged re-apply prints only the final count.
- On timeout/failure: a `still not running:` summary naming every desired slot that is not up — including `pending (not created)` slots that have no alloc record, which plain `kanea ps` omits without `-a` — plus a `kanea logs` hint when something is crash-looping.
- The state-detail rendering moves into `allocStateLabel`, shared by `ps` and the wait, so they cannot drift.

## Why

```
kanea: timed out after 1m0s with 3/9 allocs running; see `kanea ps`
```

answered neither "which six" nor "why" — the user had to go run `kanea ps -a` to find the crash-looping service and the never-created slot.

## Tests

`cmd/kanea/run_wait_test.go`: a rendering table for `allocStateLabel`, and a summary test asserting every not-up slot is named (backoff, unhealthy, not-created) and healthy running ones are not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)