### PR TITLE
docs: release prep for v0.15.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Prefer to do it by hand? Every release publishes
 signature over the checksums:
 
 ```bash
-VERSION=v0.14.0; ARCH=amd64
+VERSION=v0.15.0; ARCH=amd64
 BASE=https://github.com/m18h/kanea/releases/download/$VERSION
 
 curl -fLO $BASE/kanea_${VERSION#v}_linux_$ARCH.tar.gz

--- a/site/index.html
+++ b/site/index.html
@@ -336,7 +336,7 @@ brew install kanea</pre>
       </p>
       <div class="window">
         <div class="bar"><i></i><i></i><i></i><span>manual install</span></div>
-<pre>VERSION=v0.14.0; ARCH=amd64
+<pre>VERSION=v0.15.0; ARCH=amd64
 BASE=https://github.com/m18h/kanea/releases/download/$VERSION
 
 curl -fLO $BASE/kanea_${VERSION#v}_linux_$ARCH.tar.gz


### PR DESCRIPTION
Bumps the manual-install `VERSION` pins in `README.md` and `site/index.html` to v0.15.0, per the release checklist in AGENTS.md.

Checklist walk for this release:
1. **Docs describe what ships** — the one feature since v0.14.0 is #55 (`kanea run` wait verbosity); no doc quotes the old timeout output, and the quickstarts show no run transcript, so nothing else to update.
2. **VERSION strings** — this PR.
3. **PRD version references** — README table and AGENTS.md both say v1.61, matching `PRD.md`; no amendment this release.
4. **AGENTS.md amendment bullets** — no PRD amendment since v1.61, nothing to add.
5. **Docs land on main before the tag** — this PR and #55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)