### PR TITLE
fix(dashboard): bound connect-src to the origin, not the ws scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ and a **keyless cosign** signature over the checksums — the SBOMs are in the
 checksums, so the one signature covers them too:
 
 ```bash
-VERSION=v0.18.0; ARCH=amd64
+VERSION=v0.18.1; ARCH=amd64
 BASE=https://github.com/m18h/kanea/releases/download/$VERSION
 
 curl -fLO $BASE/kanea_${VERSION#v}_linux_$ARCH.tar.gz

--- a/cmd/kanea/agent.go
+++ b/cmd/kanea/agent.go
@@ -164,7 +164,8 @@ func runAgent(args []string) error {
 		"TSIG algorithm: hmac-sha256, hmac-sha512, ...")
 	serveDashboard := fs.Bool("dashboard", true, "serve the embedded dashboard on the API listener")
 	wsOrigins := fs.String("dashboard-origins", "",
-		"comma-separated Origins allowed to open the live-data websocket (default: same-origin only)")
+		"comma-separated Origins allowed to open the live-data websocket, and named in the "+
+			"dashboard's connect-src (default: same-origin only)")
 	listen := fs.String("listen", "",
 		"network address for the control API, e.g. "+api.DefaultListenAddr+
 			" (default: the server config's bind.api_addr, else unix socket only; \"none\" forces socket-only)")

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -227,6 +227,15 @@ CDN). Daemon-supplied strings render through React's escaping. Security headers
 are applied to the whole mux rather than per route, so a handler added later
 cannot forget them.
 
+`connect-src` is the half that bounds *exfiltration* rather than execution, and
+it names the websocket schemes because browsers have disagreed over whether
+`'self'` extends to `ws:`/`wss:`. Naming them as bare schemes would match any
+host anywhere, leaving the one bidirectional transport unbounded — so they are
+pinned to the host the request arrived on, which is by construction the origin
+the page is running on. A `Host` that is not a bare host\[:port] gets no
+websocket source at all: it cannot be a real page's origin, and a `;` in one
+would be a directive separator under the client's control.
+
 ### 3.7 Identity providers (A07)
 
 OIDC login checks four things independently, because each catches something the

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -520,7 +520,7 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 		// specific pattern. With "GET /" the two conflict: neither matches a
 		// strict superset of the other, and ServeMux panics rather than guess.
 		// The handler answers non-GET itself.
-		mux.Handle("/", dashboard.Handler("/"))
+		mux.Handle("/", dashboard.Handler("/", cfg.WSOrigins))
 		if !dashboard.Built() {
 			cfg.Logger.Warn("serving the dashboard placeholder",
 				"detail", "this binary was built without the UI; run `make dashboard && make build`")

--- a/internal/dashboard/dashboard.go
+++ b/internal/dashboard/dashboard.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"io/fs"
 	"net/http"
+	"net/url"
 	"path"
 	"strings"
 )
@@ -63,14 +64,21 @@ func assets() fs.FS {
 //   - A request for a *file* that does not exist still 404s. Falling back for
 //     those too would answer a missing script with HTML, which the browser
 //     reports as a syntax error and sends you looking in the wrong place.
-func Handler(prefix string) http.Handler {
+//
+// wsOrigins is the daemon's `--dashboard-origins` allowlist, and it is here
+// for one reason: the CSP's connect-src must permit exactly the origins the
+// websocket handshake accepts. The handshake takes same-origin plus that list
+// (api.Server.checkOrigin), so a policy that named only the first would block,
+// in the browser, a socket the daemon was configured to allow.
+func Handler(prefix string, wsOrigins []string) http.Handler {
 	files := assets()
 	server := http.FileServer(http.FS(files))
+	allowed := websocketSources(wsOrigins)
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Every answer carries these — the 200s, the 404s and the 405 alike —
 		// because the headers protect the origin, not one page on it.
-		setSecurityHeaders(w, r)
+		setSecurityHeaders(w, r, allowed)
 
 		// Registered on the bare prefix so the API's own patterns stay more
 		// specific, which means the method check lands here rather than in the
@@ -145,7 +153,9 @@ func looksLikeAsset(name string) bool {
 	return path.Ext(name) != ""
 }
 
-// contentSecurityPolicy is the depth layer under the app's own discipline.
+// cspCommon is every directive that does not depend on the request — the depth
+// layer under the app's own discipline. connect-src is the one that does, and
+// it is built per request just below.
 //
 // The dashboard renders attacker-influenced strings — log lines, service
 // names, event messages — and React escapes all of them; the ESLint ban on
@@ -156,26 +166,105 @@ func looksLikeAsset(name string) bool {
 // in the build but at runtime: xterm.js sets style attributes on its cursor
 // and selection elements, and shadcn's primitives position dialogs the same
 // way — a strict style-src blocks them and the terminal renders broken.
-// The one data: URI is the favicon; the only connections the app makes are
-// to its own origin — REST and the live socket, spelled as ws:/wss: for the
-// browsers that do not expand 'self' to the ws schemes. frame-ancestors is
-// the clickjacking guard: an admin console with stop, restart and restore
-// buttons is exactly what an invisible overlay wants.
+// The one data: URI is the favicon, which is why img-src carries the scheme
+// and font-src does not — the build ships no @font-face at all. base-uri is
+// 'none' rather than 'self': the page has no <base> element, and an injected
+// one would repoint every relative URL on it. frame-ancestors is the
+// clickjacking guard: an admin console with stop, restart and restore buttons
+// is exactly what an invisible overlay wants.
 //
 // This is the ONLY place the dashboard's CSP is set. A second header on the
 // same response is not redundancy — browsers intersect multiple policies, so
 // a stricter duplicate silently wins.
-const contentSecurityPolicy = "default-src 'self'; " +
+const cspCommon = "default-src 'self'; " +
 	"script-src 'self'; style-src 'self' 'unsafe-inline'; " +
-	"img-src 'self' data:; font-src 'self' data:; " +
-	"connect-src 'self' ws: wss:; frame-src 'none'; " +
-	"frame-ancestors 'none'; base-uri 'self'; " +
+	"img-src 'self' data:; font-src 'self'; " +
+	"frame-src 'none'; frame-ancestors 'none'; base-uri 'none'; " +
 	"form-action 'self'; object-src 'none'"
 
+// contentSecurityPolicy is the policy for one request, which is per request
+// only because of connect-src.
+//
+// The app connects to its own origin and nowhere else: REST over fetch, and
+// the live and exec sockets. `'self'` covers the fetches, but whether it also
+// covers ws:/wss: to the same host is exactly the thing browsers have
+// disagreed about — so the sockets are named. Naming them as the bare schemes
+// (`connect-src 'self' ws: wss:`) is what this used to do, and it matches any
+// host on the internet: it left connect-src — the directive whose whole job is
+// to bound where a compromised page can send what it has read — with no bound
+// at all on the one transport that is bidirectional. So the schemes are pinned
+// to the host the request came in on, which is by construction the origin the
+// page is running on, plus the daemon's configured extras.
+//
+// A Host that is not a plausible host[:port] gets neither: it cannot be the
+// origin of a real page, and letting one compose into the header would put a
+// `;` — a directive separator — under the client's control. Note that this is
+// r.Host and deliberately not X-Forwarded-Host: a forwarded header is a claim,
+// not evidence (the rule the edge is built on), and trusting one here would let
+// a request name the host its own page may talk to. A reverse proxy that
+// rewrites Host therefore needs `--dashboard-origins` — the same requirement
+// checkOrigin already imposes on it, for the same socket.
+func contentSecurityPolicy(host string, allowed []string) string {
+	connect := "; connect-src 'self'"
+	if isPlainHost(host) {
+		connect += " ws://" + host + " wss://" + host
+	}
+	for _, src := range allowed {
+		connect += " " + src
+	}
+	return cspCommon + connect
+}
+
+// websocketSources turns configured Origins into connect-src sources.
+//
+// The scheme is carried over rather than doubled: a page served over https can
+// only open wss (mixed content stops the other), so emitting both would widen
+// the policy past anything that could be used. Anything unparsable is dropped
+// silently here — it is not a source, and checkOrigin will refuse it too, so
+// the failure an operator sees is the one about the handshake rather than a
+// second one about a header.
+func websocketSources(origins []string) []string {
+	var out []string
+	for _, origin := range origins {
+		u, err := url.Parse(strings.TrimSpace(origin))
+		if err != nil || !isPlainHost(u.Host) {
+			continue
+		}
+		switch u.Scheme {
+		case "https", "wss":
+			out = append(out, "wss://"+u.Host)
+		case "http", "ws":
+			out = append(out, "ws://"+u.Host)
+		}
+	}
+	return out
+}
+
+// isPlainHost reports whether host is a bare host[:port] — a DNS name, an IPv4
+// address or a bracketed IPv6 literal, and nothing that could be read as CSP
+// syntax. Deliberately a byte allowlist rather than a parse: the question is
+// not "is this a resolvable name" but "is every byte of this safe to
+// concatenate into a header".
+func isPlainHost(host string) bool {
+	if host == "" || len(host) > 255 {
+		return false
+	}
+	for i := 0; i < len(host); i++ {
+		c := host[i]
+		switch {
+		case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c >= '0' && c <= '9':
+		case c == '.' || c == '-' || c == ':' || c == '[' || c == ']' || c == '_':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
 // setSecurityHeaders writes the browser-side hardening for one response.
-func setSecurityHeaders(w http.ResponseWriter, r *http.Request) {
+func setSecurityHeaders(w http.ResponseWriter, r *http.Request, allowed []string) {
 	h := w.Header()
-	h.Set("Content-Security-Policy", contentSecurityPolicy)
+	h.Set("Content-Security-Policy", contentSecurityPolicy(r.Host, allowed))
 	// A 404 from here is plain text; nosniff keeps a browser from reading it
 	// as something else.
 	h.Set("X-Content-Type-Options", "nosniff")

--- a/internal/dashboard/dashboard_test.go
+++ b/internal/dashboard/dashboard_test.go
@@ -33,7 +33,7 @@ func body(t *testing.T, resp *http.Response) string {
 // The root always answers with something: a real build if one is embedded, the
 // placeholder if not. A binary built without `make dashboard` must still serve.
 func TestServesTheEntryPoint(t *testing.T) {
-	resp := get(t, dashboard.Handler("/"), "/")
+	resp := get(t, dashboard.Handler("/", nil), "/")
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
@@ -48,7 +48,7 @@ func TestServesTheEntryPoint(t *testing.T) {
 // The router is client-side, so a deep link is a real URL to the user and a
 // missing file to the server. It has to reach the app.
 func TestClientRoutesFallBackToTheApp(t *testing.T) {
-	h := dashboard.Handler("/")
+	h := dashboard.Handler("/", nil)
 	for _, path := range []string{"/services", "/projects/shop", "/settings/tokens"} {
 		resp := get(t, h, path)
 		if resp.StatusCode != http.StatusOK {
@@ -64,7 +64,7 @@ func TestClientRoutesFallBackToTheApp(t *testing.T) {
 // script with HTML, which the browser reports as a syntax error and sends you
 // looking in entirely the wrong place.
 func TestMissingAssetsAreNotFound(t *testing.T) {
-	h := dashboard.Handler("/")
+	h := dashboard.Handler("/", nil)
 	for _, path := range []string{
 		"/assets/index-deadbeef.js",
 		"/assets/missing.css",
@@ -82,7 +82,7 @@ func TestMissingAssetsAreNotFound(t *testing.T) {
 // and in-binary, so the blast radius is small, but answering ../../etc/passwd
 // with anything but a 404 is still wrong.
 func TestPathTraversalIsRefused(t *testing.T) {
-	h := dashboard.Handler("/")
+	h := dashboard.Handler("/", nil)
 	for _, path := range []string{
 		"/../dashboard.go",
 		"/assets/../../dashboard.go",
@@ -99,7 +99,7 @@ func TestPathTraversalIsRefused(t *testing.T) {
 // Hashed assets are immutable and the entry point is not: caching index.html
 // hard would leave a browser pinned to the old asset hashes after an upgrade.
 func TestCacheHeaders(t *testing.T) {
-	resp := get(t, dashboard.Handler("/"), "/")
+	resp := get(t, dashboard.Handler("/", nil), "/")
 	defer func() { _ = resp.Body.Close() }()
 
 	if got := resp.Header.Get("Cache-Control"); got != "no-cache" {
@@ -111,7 +111,7 @@ func TestBuiltReportsWhetherAssetsArePresent(t *testing.T) {
 	// Both answers are legitimate — this asserts it does not panic and agrees
 	// with what the handler serves.
 	built := dashboard.Built()
-	resp := get(t, dashboard.Handler("/"), "/")
+	resp := get(t, dashboard.Handler("/", nil), "/")
 	text := body(t, resp)
 
 	isPlaceholder := strings.Contains(text, "was not built into this binary")
@@ -123,7 +123,7 @@ func TestBuiltReportsWhetherAssetsArePresent(t *testing.T) {
 // The security headers protect the origin, not one page, so every answer
 // carries them — the 200, the 404 and the 405 alike.
 func TestSecurityHeaders(t *testing.T) {
-	h := dashboard.Handler("/")
+	h := dashboard.Handler("/", nil)
 
 	cases := []struct {
 		method string
@@ -159,6 +159,8 @@ func TestSecurityHeaders(t *testing.T) {
 			// inline exception the terminal renders broken.
 			"style-src 'self' 'unsafe-inline'",
 			"frame-ancestors 'none'",
+			"base-uri 'none'",
+			"object-src 'none'",
 		} {
 			if !strings.Contains(csp, directive) {
 				t.Errorf("%s %s: CSP missing %q: %q", tc.method, tc.path, directive, csp)
@@ -167,10 +169,82 @@ func TestSecurityHeaders(t *testing.T) {
 	}
 }
 
+// connect-src bounds where a compromised page can send what it has read, so
+// the websocket schemes are pinned to the origin serving the page rather than
+// written as the bare `ws: wss:`, which matches any host anywhere.
+func TestConnectSrcIsBoundToTheRequestHost(t *testing.T) {
+	h := dashboard.Handler("/", nil)
+
+	csp := func(host string) string {
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+		req.Host = host
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		resp := w.Result()
+		_ = body(t, resp)
+		return resp.Header.Get("Content-Security-Policy")
+	}
+
+	for _, host := range []string{"kanea.example.com", "192.168.1.10:8600", "[::1]:8600"} {
+		got := csp(host)
+		if want := "connect-src 'self' ws://" + host + " wss://" + host; !strings.Contains(got, want) {
+			t.Errorf("host %q: CSP missing %q: %q", host, want, got)
+		}
+		if strings.Contains(got, "ws: ") || strings.HasSuffix(got, "ws:") || strings.Contains(got, "wss: ") {
+			t.Errorf("host %q: CSP still carries a bare websocket scheme: %q", host, got)
+		}
+	}
+
+	// A Host that is not a bare host[:port] cannot be a real page's origin, and
+	// a `;` in one would be a directive separator under the client's control.
+	for _, host := range []string{"evil.example.com; script-src *", "host with spaces", ""} {
+		got := csp(host)
+		if !strings.Contains(got, "connect-src 'self'") {
+			t.Errorf("host %q: CSP missing the fallback connect-src: %q", host, got)
+		}
+		if strings.Contains(got, "ws://") || strings.Contains(got, "wss://") {
+			t.Errorf("host %q: an unusable Host reached the header: %q", host, got)
+		}
+	}
+}
+
+// The websocket handshake accepts same-origin plus --dashboard-origins, so
+// connect-src has to permit the same set: a policy naming only the first would
+// block, in the browser, a socket the daemon was configured to allow.
+func TestConnectSrcCarriesTheConfiguredOrigins(t *testing.T) {
+	h := dashboard.Handler("/", []string{
+		"https://kanea.example.com",
+		"http://192.168.1.10:8600",
+		"not a url",     // dropped: checkOrigin will refuse it too
+		"https://a b/c", // dropped: not a bare host
+	})
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req.Host = "10.0.0.2:8600"
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	resp := w.Result()
+	_ = body(t, resp)
+	csp := resp.Header.Get("Content-Security-Policy")
+
+	// The scheme is carried over, never doubled: a page on https can only open
+	// wss, so naming ws:// as well would widen the policy past anything usable.
+	for _, want := range []string{"wss://kanea.example.com", "ws://192.168.1.10:8600"} {
+		if !strings.Contains(csp, want) {
+			t.Errorf("CSP missing %q: %q", want, csp)
+		}
+	}
+	for _, unwanted := range []string{"ws://kanea.example.com", "wss://192.168.1.10:8600", "a b"} {
+		if strings.Contains(csp, unwanted) {
+			t.Errorf("CSP unexpectedly carries %q: %q", unwanted, csp)
+		}
+	}
+}
+
 // HSTS is only claimed under TLS: browsers ignore it over plain HTTP, and a
 // node behind its own proxy may legitimately serve HTTP.
 func TestHSTSRequiresTLS(t *testing.T) {
-	h := dashboard.Handler("/")
+	h := dashboard.Handler("/", nil)
 
 	plain := get(t, h, "/")
 	_ = body(t, plain)

--- a/site/index.html
+++ b/site/index.html
@@ -308,7 +308,7 @@
     </nav>
     <div style="flex:1"></div>
     <div style="display:flex;flex-wrap:wrap;align-items:center;gap:10px 16px;font-family:'Spline Sans Mono',monospace;font-size:12px;color:var(--muted-3);">
-      <span>v0.18.0</span>
+      <span>v0.18.1</span>
       <button sc-camel-on-click="{{ toggleTheme }}" title="Toggle light and dark" aria-label="Toggle light and dark" style="display:flex;align-items:center;justify-content:center;width:32px;height:31px;padding:0;border:1px solid var(--line-3);background:transparent;color:var(--muted-3);cursor:pointer;" style-hover="color:var(--text);border-color:var(--line-strong)">
         <sc-if value="{{ isDark }}" hint-placeholder-val="{{ false }}">
           <svg width="15" height="15" sc-camel-view-box="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M2 12h2M20 12h2M4.9 4.9l1.5 1.5M17.6 17.6l1.5 1.5M19.1 4.9l-1.5 1.5M6.4 17.6l-1.5 1.5"></path></svg>


### PR DESCRIPTION
## What

The dashboard's CSP carried `connect-src 'self' ws: wss:`. The bare schemes were there because browsers have disagreed over whether `'self'` extends to `ws:`/`wss:` on the same host — but a scheme source matches **any host anywhere**, so the directive whose whole job is to bound where a compromised page can send what it has read had no bound at all on the one transport that is bidirectional.

connect-src is now built per request: `'self'` plus `ws://<host> wss://<host>` pinned to the Host the request arrived on, which is by construction the origin the page is running on.

`--dashboard-origins` contributes its own entries too, because the websocket handshake accepts same-origin **plus** that list (`api.Server.checkOrigin`) — a policy naming only the first would block, in the browser, a socket the daemon was configured to allow. Each configured Origin contributes its own scheme only: a page on https cannot open `ws://` anyway.

Deliberately `r.Host` and **not** `X-Forwarded-Host` — a forwarded header is a claim, not evidence (the rule the edge is built on), and trusting one here would let a request name the host its own page may talk to. A Host that is not a bare `host[:port]` gets no websocket source at all: a `;` in one would be a directive separator under the client's control. A reverse proxy that rewrites Host needs `--dashboard-origins`, which is the same requirement `checkOrigin` already imposes for the same socket.

Two tightenings alongside:

- `base-uri 'self'` → `'none'` — the page has no `<base>`, and an injected one repoints every relative URL on it.
- `data:` dropped from `font-src` — the build ships no `@font-face` at all; the one `data:` URI is the favicon, which is `img-src`.

`style-src 'unsafe-inline'` stays: xterm.js and the shadcn primitives set style attributes at runtime (the v0.17.2 lesson).

## Not changed

Nothing in the build was being blocked. The emitted `index.html` has no inline script, the CSS has no `@font-face` and no `url()`, there are no iframes, and the two blob downloads are `<a download href>`, which CSP does not govern.

## Verification

- `TestConnectSrcIsBoundToTheRequestHost` — the pinned sources, and that an unusable Host (`;`, spaces, empty) gets no websocket source.
- `TestConnectSrcCarriesTheConfiguredOrigins` — the allowlist entries, scheme carried over rather than doubled.
- `base-uri 'none'` and `object-src 'none'` added to the existing header assertions.

`docs/THREAT_MODEL.md` §3.6 records the reasoning; the `--dashboard-origins` flag help now says it feeds connect-src. Version strings bumped to v0.18.1 (`README.md`, `site/index.html`) per the AGENTS.md release checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)