### PR TITLE
docs: describe the full-screen log view, and bump to v0.20.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ and a **keyless cosign** signature over the checksums — the SBOMs are in the
 checksums, so the one signature covers them too:
 
 ```bash
-VERSION=v0.19.0; ARCH=amd64
+VERSION=v0.20.0; ARCH=amd64
 BASE=https://github.com/m18h/kanea/releases/download/$VERSION
 
 curl -fLO $BASE/kanea_${VERSION#v}_linux_$ARCH.tar.gz
@@ -327,7 +327,7 @@ record, just a session.
 ### The dashboard
 
 A service page charts CPU, memory, request rate and p95 on a real time axis,
-streams logs live (filterable, with copy and download), shows every restart or
+streams logs live (filterable, with copy, download and a full-screen view), shows every restart or
 deploy as **rollout progress** — the planner's own spec-hash rule, on the
 wire — and opens a **shell into any running alloc** from the browser, over the
 same exec websocket the CLI uses.

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -672,7 +672,8 @@ External:  containerd  ·  buildkitd  ·  Linux kernel (eBPF, cgroups v2, netfil
     <p>
       The dashboard is a React SPA embedded in the binary with <code>go:embed</code> and served
       by the daemon. A service page charts CPU, memory, request rate and p95 over a real
-      time axis, streams logs live (virtualized, filterable, copy and download), shows a
+      time axis, streams logs live (virtualized, filterable, copy, download, and a
+      full-screen view that keeps your place in the buffer across the toggle), shows a
       restart or deploy as rollout progress — the same spec-hash rule the planner uses,
       served on the wire since v1.64 — and gives an admin a <b>shell into any running
       alloc</b>, over the same exec websocket the CLI uses: the CSRF token rides the

--- a/site/index.html
+++ b/site/index.html
@@ -308,7 +308,7 @@
     </nav>
     <div style="flex:1"></div>
     <div style="display:flex;flex-wrap:wrap;align-items:center;gap:10px 16px;font-family:'Spline Sans Mono',monospace;font-size:12px;color:var(--muted-3);">
-      <span>v0.19.0</span>
+      <span>v0.20.0</span>
       <button sc-camel-on-click="{{ toggleTheme }}" title="Toggle light and dark" aria-label="Toggle light and dark" style="display:flex;align-items:center;justify-content:center;width:32px;height:31px;padding:0;border:1px solid var(--line-3);background:transparent;color:var(--muted-3);cursor:pointer;" style-hover="color:var(--text);border-color:var(--line-strong)">
         <sc-if value="{{ isDark }}" hint-placeholder-val="{{ false }}">
           <svg width="15" height="15" sc-camel-view-box="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M2 12h2M20 12h2M4.9 4.9l1.5 1.5M17.6 17.6l1.5 1.5M19.1 4.9l-1.5 1.5M6.4 17.6l-1.5 1.5"></path></svg>


### PR DESCRIPTION
Release checklist items 1 and 2, landing on `main` before the tag (item 5).

**Item 1 — docs describe what ships.** The dashboard prose in `README.md` and `site/docs/index.html` enumerated the log viewer's abilities (filter, copy, download); both now name the full-screen view, and `site/docs` adds the part worth knowing — your place in the buffer survives the toggle.

**Item 2 — version strings.** Both move to `v0.20.0`:
- `README.md:47` — `VERSION=v0.20.0` in the manual-install example
- `site/index.html:311` — the `<span>v0.20.0</span>` badge beside the theme toggle

These two don't look alike, and a grep for one doesn't find the other — which is how the site badge shipped stale in v0.18.0. So this was a grep for the tag being *replaced* (`v0\.19\.`), and it now returns nothing across `README.md` and `site/`.

**Items 3 and 4** need no change and were verified: `PRD.md` is at v1.70 and both references to it (`AGENTS.md` header, README's documentation table, AGENTS' key-documents table) already say v1.70; the four v1.70 guidance bullets are in AGENTS.md's "things a change is most likely to trip over" list.

**`site/index.html` is otherwise untouched.** AGENTS.md says it's a design-tool export that must never be hand-edited; the version badge is the one hand-edit the checklist sanctions. A feature card for the full-screen view would have to come back through the tool — and a log toggle reads as a dashboard detail rather than a platform capability, so it's documented in README and `site/docs` instead.

`docs/DR_RUNBOOK.md` needs nothing: no backup or restore behaviour changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)