### PR TITLE
docs: bump the version strings to v0.21.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ and a **keyless cosign** signature over the checksums. The SBOMs are listed in
 the checksums, so that one signature covers them too:
 
 ```bash
-VERSION=v0.20.0; ARCH=amd64
+VERSION=v0.21.0; ARCH=amd64
 BASE=https://github.com/m18h/kanea/releases/download/$VERSION
 
 curl -fLO $BASE/kanea_${VERSION#v}_linux_$ARCH.tar.gz

--- a/site/index.html
+++ b/site/index.html
@@ -308,7 +308,7 @@
     </nav>
     <div style="flex:1"></div>
     <div style="display:flex;flex-wrap:wrap;align-items:center;gap:10px 16px;font-family:'Spline Sans Mono',monospace;font-size:12px;color:var(--muted-3);">
-      <span>v0.20.0</span>
+      <span>v0.21.0</span>
       <button sc-camel-on-click="{{ toggleTheme }}" title="Toggle light and dark" aria-label="Toggle light and dark" style="display:flex;align-items:center;justify-content:center;width:32px;height:31px;padding:0;border:1px solid var(--line-3);background:transparent;color:var(--muted-3);cursor:pointer;" style-hover="color:var(--text);border-color:var(--line-strong)">
         <sc-if value="{{ isDark }}" hint-placeholder-val="{{ false }}">
           <svg width="15" height="15" sc-camel-view-box="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M2 12h2M20 12h2M4.9 4.9l1.5 1.5M17.6 17.6l1.5 1.5M19.1 4.9l-1.5 1.5M6.4 17.6l-1.5 1.5"></path></svg>


### PR DESCRIPTION
Release prep for v0.21.0. The two version strings that name a release and do not look alike: `README.md`'s manual-install example (`VERSION=`) and the bare `<span>` beside `site/index.html`'s theme toggle.

The rest of the release checklist was already satisfied:

- **Docs describe what ships.** README documents the Projects and Storage pages, and `site/docs/index.html` documents the v1.76 secret delivery (`secret:` gives a tmpfs path, `secret-env:` inlines the value), both of which landed after v0.20.0.
- **PRD version references** match `PRD.md`'s v1.78 in both README and AGENTS.md, as of #84.
- **The amendment bullets** for v1.72 through v1.78 are in AGENTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)