### PR TITLE
fix(site): mobile layout, and anchor jumps that land on the section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -325,6 +325,13 @@ These come from PRD §18 and the security review. Violating them is a bug, even 
                        # stylesheet with the old landing page leaves the docs unstyled. It did.
                        # docs/ also links ../#install and expects that id to exist on the
                        # export; #homebrew stopped existing and the link had to move.
+                       # ONE hand edit exists: the MOBILE-PATCH block in index.html's head
+                       # (mobile overrides + anchor offset + the deep-link re-jump script).
+                       # Re-apply it after any tool re-export. Two traps it embodies: the
+                       # runtime re-fetches the page and regexes for the template tag, so
+                       # that tag's literal name must never appear in a comment; and the
+                       # runtime re-serializes inline styles through React, so overrides
+                       # match the rendered form (minmax(0px, …)), not the template's.
                        # install.sh there is COPIED from scripts/ by .github/workflows/pages.yml
                        # and gitignored: two copies drift, and the one that drifts is curled
 /scripts/install.sh    # the installer; its asset names are a contract with .github/workflows/release.yml

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -2753,10 +2753,13 @@ cat /sys/fs/cgroup/kanea-workloads.slice/memory.current</pre>
     // The heading nearest the top of the viewport wins. An IntersectionObserver
     // alone reports whatever crosses the boundary, which flickers between two
     // headings when a short section scrolls past; this picks deterministically.
+    // The threshold matches the sticky chrome (header alone on desktop, header
+    // plus the contents bar on mobile) so the mark agrees with where a jump lands.
     function update() {
+      var offset = matchMedia('(max-width: 900px)').matches ? 140 : 90;
       var best = null, bestTop = -Infinity;
       for (var i = 0; i < targets.length; i++) {
-        var t = targets[i].getBoundingClientRect().top - 90;
+        var t = targets[i].getBoundingClientRect().top - offset;
         if (t <= 0 && t > bestTop) { bestTop = t; best = targets[i]; }
       }
       if (!best && targets.length) best = targets[0];

--- a/site/index.html
+++ b/site/index.html
@@ -14,6 +14,87 @@
 <script src="assets/react.production.min.js"></script>
 <script src="assets/react-dom.production.min.js"></script>
 <script src="assets/dc-runtime.js"></script>
+
+<!-- MOBILE-PATCH: hand-applied responsive overrides + anchor/deep-link fixes.
+     Everything else in this file is a design-tool export (see AGENTS.md); if the
+     page is re-exported from the tool, re-apply this block. It deliberately lives
+     in the head, outside the x-dc template, so the dc runtime never manages it.
+     (Never write the template tag's literal name in a comment here: the runtime
+     re-fetches this page and locates the template with a regex for it.)
+     The style substrings below match the runtime-rendered serialization
+     (minmax(0px, …), spaces after colons), not the template source. -->
+<script>
+  // Deep links (the docs' ../#install, shared fragment URLs) point at sections
+  // the runtime renders asynchronously: the browser's own fragment jump runs
+  // while the template is still hidden and lands nowhere. Once the rendered
+  // tree exists, re-do the jump; scroll-margin-top below frames it.
+  (function () {
+    if (!location.hash) return;
+    var id;
+    try { id = decodeURIComponent(location.hash.slice(1)); } catch (e) { return; }
+    var done = false;
+    function jump() {
+      if (done) return;
+      var el = document.getElementById(id);
+      if (el && el.closest('#dc-root')) {
+        done = true;
+        el.scrollIntoView();
+        obs.disconnect();
+      }
+    }
+    var obs = new MutationObserver(jump);
+    obs.observe(document.documentElement, { childList: true, subtree: true });
+    setTimeout(function () { obs.disconnect(); }, 6000);
+    jump();
+  })();
+</script>
+<style>
+  /* Anchor jumps land on the section, framed — not with its title jammed under
+     the sticky header. The header is ~62px tall; 76px leaves a small gap. */
+  section[id] { scroll-margin-top: 76px; }
+
+  @media (max-width: 900px) {
+    section[id] { scroll-margin-top: 72px; }
+
+    /* One compact sticky row: brand, version, theme, GitHub. The section links
+       wrap into three rows on a phone, and as a sticky block they cover every
+       anchor target. Mobile users scroll a landing page rather than nav-hop. */
+    #dc-root header { flex-wrap: nowrap !important; gap: 10px !important; padding: 12px 16px !important; }
+    #dc-root header nav { display: none !important; }
+
+    /* Every fixed multi-column grid becomes one column. */
+    #dc-root [style*="grid-template-columns: 66px minmax(0px, 1fr)"],
+    #dc-root [style*="grid-template-columns: minmax(0px, 0.93fr) minmax(0px, 1.07fr)"],
+    #dc-root [style*="grid-template-columns: minmax(0px, 1fr) minmax(0px, 1fr)"],
+    #dc-root [style*="grid-template-columns: minmax(0px, 1fr) minmax(0px, 1.02fr)"],
+    #dc-root [style*="grid-template-columns: minmax(0px, 1.08fr) minmax(0px, 0.92fr)"],
+    #dc-root [style*="grid-template-columns: repeat(3, minmax(0px, 1fr))"] {
+      grid-template-columns: minmax(0px, 1fr) !important;
+    }
+    #dc-root [style*="grid-template-columns: repeat(4, minmax(0px, 1fr))"] {
+      grid-template-columns: repeat(2, minmax(0px, 1fr)) !important;
+    }
+
+    /* The 66px vertical-label rails go; their sections keep the content cell. */
+    #dc-root div:has(> [style*="writing-mode: vertical-rl"]) { display: none !important; }
+
+    /* Desktop paddings become phone-sized. */
+    #dc-root [style*="padding: 70px 36px"] { padding: 48px 20px 44px !important; }
+    #dc-root [style*="padding: 76px 44px 60px 36px"] {
+      padding: 44px 20px 36px !important;
+      border-right: 0 !important;
+      border-bottom: 1px solid var(--line) !important;
+    }
+    #dc-root [style*="padding: 30px 30px 32px"] { padding: 20px 16px 24px !important; }
+    #dc-root section[style*="padding: 74px 36px"] { padding: 48px 20px !important; }
+    #dc-root section[style*="padding: 15px 36px"] { padding: 12px 16px !important; }
+    #dc-root footer[style*="padding: 40px 36px"] { padding: 28px 20px 36px !important; }
+
+    /* The comparison table keeps its columns and scrolls sideways. */
+    #dc-root #compare [style*="repeat(4, minmax(0px, 1fr))"] { min-width: 660px; }
+    #dc-root #compare [style="border: 1px solid var(--line-2);"] { overflow-x: auto; }
+  }
+</style>
 </head>
 <body>
 <x-dc>

--- a/site/style.css
+++ b/site/style.css
@@ -308,6 +308,14 @@ footer .sp { margin-left: auto; }
   scroll-margin-top: 78px;
 }
 .prose h4 { font-size: 1.02rem; margin: 30px 0 8px; scroll-margin-top: 78px; }
+@media (max-width: 900px) {
+  /* Selecting a section must move to the section, not strand its title behind
+     the sticky chrome: on a narrow screen that is the 58px header plus the
+     ~62px contents bar, so 78px is 40-odd px short and the heading lands
+     hidden. 132px clears both with a small gap. */
+  .prose h2, .prose h3, .prose h4 { scroll-margin-top: 132px; }
+  .prose h2 { margin: 64px 0 18px; }
+}
 .prose > p:first-of-type { font-size: 1.05rem; color: var(--muted); }
 .prose p { margin: 0 0 16px; }
 .prose ul, .prose ol { margin: 0 0 16px; padding-left: 22px; }


### PR DESCRIPTION
## What & why

The site was close to unusable on a phone, and picking a section did not take you to the section.

**Landing page** had no responsive rules at all: every grid kept its desktop columns on a 390px screen, the header wrapped into three sticky rows, and an anchor jump stranded the section's title behind that header. Deep links were worse: the docs' `../#install` (and any shared fragment URL) landed *nowhere*, because the dc runtime renders asynchronously over a hidden template and the browser's own fragment jump finds nothing to scroll to.

**Docs page** cleared only the 58px header with its 78px `scroll-margin-top`; on mobile the sticky chrome is the header *plus* the ~62px contents bar, so a picked section landed with its title hidden.

What changed:

- **Landing page** — one marked `MOBILE-PATCH` block in the head, outside the runtime's template: `scroll-margin-top` on `section[id]` so a jump lands on the section framed (not on its title); one compact sticky header row on phones; fixed multi-column grids collapse (4-col → 2); the 66px vertical rails go; paddings go phone-sized; the compare table scrolls sideways; and a small script re-applies the fragment once the rendered tree exists, so deep links work.
- **Docs page** — 132px scroll margin on mobile (header + contents bar), and the current-section marker threshold matches the chrome per breakpoint so the highlighted contents entry agrees with where a jump lands.
- **AGENTS.md** — records the hand-applied patch, that it must be re-applied after any design-tool re-export, and the two traps found while building it (the runtime regexes the re-fetched page for the template tag, so its literal name can never appear in a comment; and overrides must match React's re-serialized inline styles, `minmax(0px, …)`, not the template source).

Verified with headless-browser screenshots at 390px and 1280px: every section deep link lands at exactly the intended offset with its title visible, all grids collapse, the table scrolls, and desktop is pixel-unchanged.

Site-only change: no Go, dashboard, or spec surface is touched; CI's gates don't exercise `site/` (pages.yml publishes it from main).

## Checklist

- [x] This change follows `PRD.md`, or the PRD was amended first in this PR (AGENTS.md constraint #1) — no PRD surface
- [x] `make check` passes locally (vet, test, lint, security gates) — N/A: static site files only, no gate covers `site/`; CI runs regardless
- [x] No secrets/credentials added (gitleaks-clean); secrets are `secret:`-referenced, never inlined
- [x] Metrics/logs did not touch the Store; mutations go through `Store` with monotonic indexes — N/A
- [x] New API/WS/MCP routes are deny-by-default behind auth middleware — N/A
- [x] Tests added/updated (table-driven; reconciler & jobspec >80% coverage) — N/A: verified visually via headless browser at two widths
- [x] Docs updated (`PRD.md`, `AGENTS.md`, `docs/`) where behavior changed — AGENTS.md site paragraph records the patch