### PR TITLE
fix: the two flakes that reddened the v0.23.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,12 +118,33 @@ jobs:
       - name: Build the offline bundles
         run: |
           set -euo pipefail
+
+          # The two commands below are the only ones in this job that depend
+          # on a third party's network weather: the install fetches upstream
+          # release archives, and the bundle exports an image from Docker Hub.
+          # A CDN connection reset mid-pull failed the v0.23.0 release with
+          # nothing wrong with the code, so each gets three attempts with a
+          # widening pause. Every retry is announced and the last failure is
+          # still a failure: this hides a flaky network, never a broken build.
+          retry() {
+            local attempt=1
+            until "$@"; do
+              if [ "$attempt" -ge 3 ]; then
+                echo "::error::failed after $attempt attempts: $*"
+                return 1
+              fi
+              echo "::warning::attempt $attempt failed, retrying: $*"
+              sleep $((attempt * 15))
+              attempt=$((attempt + 1))
+            done
+          }
+
           tar -C dist -xzf "dist/kanea_${VERSION#v}_linux_amd64.tar.gz"
-          sudo ./dist/kanea install --only containerd,runc
+          retry sudo ./dist/kanea install --only containerd,runc
           sudo systemctl daemon-reload
           sudo systemctl enable --now kanea-containerd.service
           for arch in amd64 arm64; do
-            sudo ./dist/kanea bundle create --arch "$arch" \
+            retry sudo ./dist/kanea bundle create --arch "$arch" \
               -o "dist/kanea_${VERSION#v}_linux_${arch}_bundle.tar.gz"
           done
           sudo chown "$(id -u):$(id -g)" dist/*_bundle.tar.gz

--- a/dashboard/src/App.test.tsx
+++ b/dashboard/src/App.test.tsx
@@ -60,16 +60,9 @@ const signedIn = {
 
 beforeEach(() => {
   vi.stubGlobal('WebSocket', silentWebSocket)
-  // Node's own globals shadow jsdom's here, so neither of these exists in the
-  // test environment even though every browser has both. The shell reads them
-  // for the theme toggle, which is not what these tests are about.
-  vi.stubGlobal('matchMedia', () => ({ matches: false }))
-  const store = new Map<string, string>()
-  vi.stubGlobal('localStorage', {
-    getItem: (k: string) => store.get(k) ?? null,
-    setItem: (k: string, v: string) => void store.set(k, v),
-    removeItem: (k: string) => void store.delete(k),
-  })
+  // localStorage lives in test/setup.ts, defined rather than stubbed: the
+  // theme effect writes it, and a stub that afterEach removes is a global
+  // that vanishes under an effect still in flight. See the note there.
   window.history.pushState({}, '', '/')
 })
 

--- a/dashboard/src/test/globals.test.ts
+++ b/dashboard/src/test/globals.test.ts
@@ -1,0 +1,26 @@
+import { expect, it, vi } from 'vitest'
+
+/**
+ * The environment's own contract, pinned. Both of these held only by accident
+ * before setup.ts defined localStorage: the theme effect writes storage, and
+ * a test file that stubbed it handed the next flushed effect an `undefined`
+ * global the moment its afterEach unstubbed. That failure lands in whichever
+ * test happens to be running, which is why it reads as an unrelated flake.
+ */
+it('storage outlives a test that unstubs every global', () => {
+  vi.stubGlobal('localStorage', {
+    getItem: () => null,
+    setItem: () => {},
+    removeItem: () => {},
+  })
+  vi.unstubAllGlobals()
+
+  expect(window.localStorage).toBeDefined()
+  expect(() => window.localStorage.setItem('kanea-theme', 'dark')).not.toThrow()
+})
+
+it('storage is empty at the start of a test, whatever the last one wrote', () => {
+  expect(window.localStorage.getItem('kanea-theme')).toBeNull()
+  window.localStorage.setItem('kanea-theme', 'light')
+  expect(window.localStorage.getItem('kanea-theme')).toBe('light')
+})

--- a/dashboard/src/test/setup.ts
+++ b/dashboard/src/test/setup.ts
@@ -1,4 +1,4 @@
-import { vi } from 'vitest'
+import { beforeEach, vi } from 'vitest'
 
 /**
  * uPlot draws on a canvas 2d context, which jsdom does not provide: any test
@@ -40,4 +40,57 @@ vi.mock('uplot', () => {
     }
   }
   return { default: FakeUPlot }
+})
+
+/**
+ * localStorage, defined once for every test file. Node's own globals shadow
+ * jsdom's, so it does not exist in this environment even though every browser
+ * has it, and useTheme reads it on mount and writes it in an effect.
+ *
+ * It is *defined* here rather than stubbed per test, and that is the whole
+ * point: `vi.unstubAllGlobals()` in an afterEach restores a stubbed global to
+ * what it was, which here is `undefined`. A passive effect flushing after a
+ * test's teardown then calls setItem on nothing, which fails one run in
+ * dozens and passes every rerun; it reddened a dashboard gate before it was
+ * understood. A definition survives unstubbing, so the window a component
+ * sees is the same one whatever order the hooks run in. Isolation comes from
+ * clearing the store between tests instead.
+ */
+class MemoryStorage implements Storage {
+  private store = new Map<string, string>()
+
+  get length(): number {
+    return this.store.size
+  }
+
+  key(index: number): string | null {
+    return [...this.store.keys()][index] ?? null
+  }
+
+  getItem(key: string): string | null {
+    return this.store.get(key) ?? null
+  }
+
+  setItem(key: string, value: string): void {
+    this.store.set(key, String(value))
+  }
+
+  removeItem(key: string): void {
+    this.store.delete(key)
+  }
+
+  clear(): void {
+    this.store.clear()
+  }
+}
+
+const memoryStorage = new MemoryStorage()
+Object.defineProperty(window, 'localStorage', {
+  value: memoryStorage,
+  configurable: true,
+  writable: true,
+})
+
+beforeEach(() => {
+  memoryStorage.clear()
 })


### PR DESCRIPTION
Two independent flakes, both found while cutting v0.23.0, neither a product defect. `make check` gates `release.yml`, so either one can cost a release for nothing.

## 1. The dashboard flake — a global that vanishes mid-teardown

`App.test.tsx` stubbed `localStorage` in a `beforeEach` and `vi.unstubAllGlobals()`'d in an `afterEach`. Unstubbing restores a global to **what it was**, and what it was here is `undefined`: Node's own globals shadow jsdom's, so this environment has no `localStorage` at all unless something puts one there (`ExperimentalWarning: localStorage is not available because --localstorage-file was not provided`).

`useTheme` writes storage in a passive effect, so a flush landing after a test's teardown — the sync re-render path, not bound by that test's `act()` — called `setItem` on `undefined`, failing **whichever test happened to be running**. One run in dozens; passes on every rerun. That is why it reads as unrelated.

The store is now *defined* on `window` in `test/setup.ts`, which survives unstubbing; isolation comes from clearing it between tests instead. The `matchMedia` stub goes too — nothing has read it since `useTheme` stopped consulting the OS preference.

`src/test/globals.test.ts` pins both properties. Verified to bite: with the definition removed it fails with `expected undefined to be defined` and `Cannot read properties of undefined (reading 'getItem')` — the production symptom exactly. Full suite run 5× clean afterwards (35 files, 271 tests).

## 2. The release flake — an unretried pull from Docker Hub

The v0.23.0 run died at "Build the offline bundles" when Docker Hub's CDN reset the connection mid-pull of the buildkit image, *after* gates passed and binaries were built. Re-running the same commit went green.

`kanea install` (upstream release archives) and `kanea bundle create` (the image export) are the only commands in that job reaching a third party, so each gets three attempts with a widening pause.

The bound is visible rather than silent: every retry prints a `::warning::` and a persistent failure still fails the step. Exercised all three paths locally — clean success is silent, a twice-failing command recovers and says so, and an always-failing one exits 1 under `set -e` without reaching the next line. **This hides a flaky network, never a broken build.**

## Not done here

`ci.yml`'s install-smoke jobs run the same two commands and have the same exposure. Left alone deliberately — that is a judgement call about masking failures in the gate that guards correctness, and worth deciding separately.

## Constraints

No product code, no PRD deviation, no Store or spec surface touched. Go untouched entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)