### PR TITLE
docs: release prep for v0.23.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ and a **keyless cosign** signature over the checksums. The SBOMs are listed in
 the checksums, so that one signature covers them too:
 
 ```bash
-VERSION=v0.23.0; ARCH=amd64
+VERSION=v0.23.1; ARCH=amd64
 BASE=https://github.com/m18h/kanea/releases/download/$VERSION
 
 curl -fLO $BASE/kanea_${VERSION#v}_linux_$ARCH.tar.gz

--- a/site/index.html
+++ b/site/index.html
@@ -389,7 +389,7 @@
     </nav>
     <div style="flex:1"></div>
     <div style="display:flex;flex-wrap:wrap;align-items:center;gap:10px 16px;font-family:'Spline Sans Mono',monospace;font-size:12px;color:var(--muted-3);">
-      <span>v0.23.0</span>
+      <span>v0.23.1</span>
       <button sc-camel-on-click="{{ toggleTheme }}" title="Toggle light and dark" aria-label="Toggle light and dark" style="display:flex;align-items:center;justify-content:center;width:32px;height:31px;padding:0;border:1px solid var(--line-3);background:transparent;color:var(--muted-3);cursor:pointer;" style-hover="color:var(--text);border-color:var(--line-strong)">
         <sc-if value="{{ isDark }}" hint-placeholder-val="{{ false }}">
           <svg width="15" height="15" sc-camel-view-box="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M2 12h2M20 12h2M4.9 4.9l1.5 1.5M17.6 17.6l1.5 1.5M19.1 4.9l-1.5 1.5M6.4 17.6l-1.5 1.5"></path></svg>


### PR DESCRIPTION
The two version strings that name a release: README's manual-install `VERSION` and the site header's `<span>`.

**Why a v0.23.1 with no product change.** v0.23.0 shipped, then its release was withdrawn so the tag could be moved onto two flake fixes that landed just after it (#89). The move was refused by the `protect-release-tags` ruleset — `deletion`, `update` and `non_fast_forward` are all blocked on `refs/tags/v*`, which is the guardrail working as intended. Rather than relax it, the version is retired: republishing v0.23.0 from a rebuild would have handed the same version number a different set of digests, and the Homebrew tap had already pinned the originals.

So v0.23.1 is v0.23.0 plus a vitest setup fix and a release-workflow retry — no user-visible change, and `latest` points at a v0.23.x again.

Checklist items 1, 3 and 4 need nothing: no user-visible behaviour changed since v0.23.0, the PRD stays at v1.80, and there is no amendment to record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)