### PR TITLE
docs(site): say what the name means

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -770,10 +770,10 @@
   <section style="padding:74px 36px;border-bottom:1px solid var(--line);">
     <div style="max-width:1000px;margin:0 auto;">
       <p style="margin:0;font-family:'Bricolage Grotesque',sans-serif;font-size:40px;line-height:1.16;letter-spacing:-.035em;font-weight:700;color:var(--heading);text-wrap:balance;">
-        “Kanea was specified before it was written, and the document is still the north star.”
+        “Kanea is the Twi word for light. A node should be something you can see all the way into.”
       </p>
       <div style="margin-top:22px;font-family:'Spline Sans Mono',monospace;font-size:12px;letter-spacing:.12em;color:var(--muted-3);">
-        EVERY ARCHITECTURAL DECISION, NAMING RULE AND THREAT BOUNDARY IS WRITTEN DOWN
+        TWI IS AN AKAN LANGUAGE, SPOKEN IN GHANA
       </div>
     </div>
   </section>


### PR DESCRIPTION
## What & why

The pull quote above the documentation section read:

> “Kanea was specified before it was written, and the document is still the north star.”

The section immediately below it is titled **“The specification is the product”** and makes that case at length, with links to the PRD, the threat model and the runbook. So the slot was spending forty-point type on a claim the page already makes better a screen later.

It now explains the name, which nothing on the site did anywhere: **kanea is the Twi word for light**. The supporting line changes with it — the old one (`EVERY ARCHITECTURAL DECISION, NAMING RULE AND THREAT BOUNDARY IS WRITTEN DOWN`) argued for the claim that is gone, so leaving it would have orphaned it against an etymology.

Nothing is lost from the page: the north-star message is still there, in the section that owns it.

## Heads-up for the merger

`site/index.html` is a design-tool export, and AGENTS.md says it must not be hand-edited because the next re-export drops anything applied here. **This edit needs mirroring in the tool.** It is applied by hand because the copy change was asked for directly; the caveat is in the commit message too so it is not lost.

## Verification

Rendered locally through the page's own React runtime (it is not static HTML): the quote and subtitle come out as intended, `text-wrap: balance` breaks the line sensibly, curly quotes survive, and there are no page errors or failed requests. Checked that no other page on the site already explains the name, so this does not duplicate anything.

## Checklist

- [x] This change follows `PRD.md` — copy only, no behaviour
- [x] `make check` passes locally — n/a, no code changed; the file is not in any gate
- [x] No secrets/credentials added
- [x] Metrics/logs did not touch the Store — n/a
- [x] New API/WS/MCP routes are deny-by-default — n/a
- [x] Tests added/updated — n/a
- [x] Docs updated where behavior changed — this is the docs change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
