### PR TITLE
fix(dashboard): unbreak npm ci after the dependency bumps

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -16,7 +16,7 @@
         "clsx": "^2.1.1",
         "lucide-react": "^1.31.0",
         "react": "^19.2.8",
-        "react-dom": "^18.3.1",
+        "react-dom": "^19.2.8",
         "tailwind-merge": "^3.6.0",
         "uplot": "^1.6.32",
         "zod": "^4.4.3"
@@ -26,7 +26,7 @@
         "@testing-library/react": "^16.1.0",
         "@types/node": "^26.1.2",
         "@types/react": "^19.2.18",
-        "@types/react-dom": "^18.3.5",
+        "@types/react-dom": "^19.2.4",
         "@types/ws": "^8.18.1",
         "@vitejs/plugin-react": "^6.0.5",
         "@vitest/coverage-v8": "^4.1.10",
@@ -1186,13 +1186,13 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.3.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@types/react": "^18.0.0"
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@types/ws": {
@@ -3079,6 +3079,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jsdom": {
@@ -3500,18 +3501,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
       }
     },
     "node_modules/lru-cache": {
@@ -4141,16 +4130,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^18.3.1"
+        "react": "^19.2.8"
       }
     },
     "node_modules/react-is": {
@@ -4302,13 +4290,10 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "6.3.1",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -22,7 +22,7 @@
     "clsx": "^2.1.1",
     "lucide-react": "^1.31.0",
     "react": "^19.2.8",
-    "react-dom": "^18.3.1",
+    "react-dom": "^19.2.8",
     "tailwind-merge": "^3.6.0",
     "uplot": "^1.6.32",
     "zod": "^4.4.3"
@@ -32,7 +32,7 @@
     "@testing-library/react": "^16.1.0",
     "@types/node": "^26.1.2",
     "@types/react": "^19.2.18",
-    "@types/react-dom": "^18.3.5",
+    "@types/react-dom": "^19.2.4",
     "@types/ws": "^8.18.1",
     "@vitejs/plugin-react": "^6.0.5",
     "@vitest/coverage-v8": "^4.1.10",

--- a/dashboard/src/hooks/useLiveTopic.ts
+++ b/dashboard/src/hooks/useLiveTopic.ts
@@ -72,7 +72,7 @@ export function useLiveTopic<S extends z.ZodTypeAny>(
       }
       if (frame.type !== 'data') return
 
-      const parsed = schema.safeParse(frame.data) as z.SafeParseReturnType<unknown, z.infer<S>>
+      const parsed = schema.safeParse(frame.data) as z.ZodSafeParseResult<z.infer<S>>
       if (!parsed.success) {
         setState((s) => ({
           ...s,


### PR DESCRIPTION
## What & why

**`main` is red right now.** `npm ci` fails with `ERESOLVE`, which takes the dashboard CI gate *and* the release workflow's `make dashboard` step with it — so releases are blocked until this lands.

Two dependency bumps that merged within a minute of each other each left something behind.

### 1. react 19 with react-dom 18 (#105)

#105 bumped `react` and `@types/react` to 19 and left `react-dom` at `^18.3.1` and `@types/react-dom` at `^18.3.5`. react-dom must track react's major; the error npm actually reports is the types half, because `@types/react-dom@18` peer-requires `@types/react@^18`:

```
npm error While resolving: @types/react-dom@18.3.7
npm error Found: @types/react@19.2.18
npm error Conflicting peer dependency: @types/react@18.3.31
```

`react-dom` and `@types/react-dom` now match, at 19.2.8 and 19.2.4.

### 2. zod 4 removed `z.SafeParseReturnType` (#100)

#100 bumped zod 3 → 4, which removed that type. `useLiveTopic.ts:75` casts to it.

This one was **latent rather than loud**: nothing could install, so nothing ran lint or typecheck to find it. zod 4 calls the type `ZodSafeParseResult` and takes the output type alone — the input parameter went with the old name.

**Neither is visible without the other.** Fixing the peer conflict is what lets an install succeed, and only then does the zod error surface (as 1 typecheck error and 4 `no-unsafe-*` lint errors, since the unresolvable type poisons everything downstream of the cast).

## Verification

Done the way CI does it, from an empty `node_modules` — `npm install` alone would not have proven anything, since the failing command is `npm ci`:

- `rm -rf node_modules && npm ci` → **succeeds** (fails on main)
- `make dashboard` → clean end to end: lint **0 errors**, typecheck clean, **39 test files / 310 tests passing**, build ok, `npm audit` 0 vulnerabilities

The 2 remaining lint warnings are pre-existing, in virtualizer code untouched here.

## The judgement call

Going **forward** to React 19 rather than reverting react to 18. Both restore a working install; this one keeps the bump Dependabot proposed instead of undoing it and having it return next week.

Worth stating plainly: **React 19 is a major**, and 310 passing tests are good evidence but not proof that nothing changed at runtime. If you would rather sit on 18 for now, reverting `react`/`@types/react` is the same size of change and the zod fix stands either way.

## Checklist

- [x] This change follows `PRD.md` — dependency repair, no behaviour change
- [x] `make check` passes locally — `make dashboard` in full; this PR is what makes it runnable again
- [x] No secrets/credentials added
- [x] Metrics/logs did not touch the Store — n/a
- [x] New API/WS/MCP routes are deny-by-default — n/a
- [x] Tests added/updated — n/a; the existing 310 are what verify this
- [x] Docs updated where behavior changed — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)
