### PR TITLE
fix(dashboard): read init steps from the lowercase key the daemon sends

### DIFF
--- a/dashboard/mock/api.ts
+++ b/dashboard/mock/api.ts
@@ -9,6 +9,7 @@ import {
   currentIndex,
   events,
   findService,
+  initLogLines,
   history,
   logLine,
   nodeSeriesNames,
@@ -450,6 +451,7 @@ function liveSocket(ws: WebSocket): void {
       topic: string
       project?: string
       service?: string
+      container?: string
       history?: boolean
       series?: string[]
       allocs?: boolean
@@ -482,6 +484,16 @@ function liveSocket(ws: WebSocket): void {
     if (sub.topic === 'node') {
       send(key, 'node', { ...nodeStats(), ...seed(nodeSeriesNames, 'node') })
     }
+    // An init step's log is history, not a stream (v1.92: the sequence ran
+    // once, on alloc 0, and the file stopped growing when the step exited).
+    // The whole transcript rides the subscribe, and the store-change rebroad-
+    // casts skip it: `seeded` guards the once, exactly like history seeds.
+    if (sub.topic === 'logs' && sub.container && sub.project && sub.service && !sub.seeded) {
+      sub.seeded = true
+      const svc = findService(sub.project, sub.service)
+      const lines = svc ? initLogLines(svc, sub.container) : []
+      if (lines.length > 0) send(key, 'logs', { lines })
+    }
     if (sub.topic === 'stats' && sub.project && sub.service) {
       const svc = findService(sub.project, sub.service)
       if (svc) {
@@ -504,6 +516,7 @@ function liveSocket(ws: WebSocket): void {
       project?: string
       service?: string
       tail?: number
+      container?: string
       history?: boolean
       history_series?: string[]
       history_allocs?: boolean
@@ -524,6 +537,7 @@ function liveSocket(ws: WebSocket): void {
         topic: string
         project?: string
         service?: string
+        container?: string
         history?: boolean
         series?: string[]
         allocs?: boolean
@@ -534,6 +548,11 @@ function liveSocket(ws: WebSocket): void {
       if (frame.history_allocs) sub.allocs = true
       if (frame.project) sub.project = frame.project
       if (frame.service) sub.service = frame.service
+      // R32: a logs subscription may name an init container. The client keys
+      // task and init feeds identically, so re-subscribing with a different
+      // container replaces the sub at this key - which is the daemon's shape
+      // too: switching steps is a new feed, not a filter on the old one.
+      if (frame.container) sub.container = frame.container
       subs.set(key, sub)
       snapshot(key)
     }
@@ -554,6 +573,9 @@ function liveSocket(ws: WebSocket): void {
   const logTimer = setInterval(() => {
     for (const [key, sub] of subs) {
       if (sub.topic !== 'logs' || !sub.project || !sub.service) continue
+      // A finished init step's log does not grow; its transcript went out
+      // with the subscribe.
+      if (sub.container) continue
       const svc = findService(sub.project, sub.service)
       if (!svc) continue
       // A batch per tick, like the daemon (PRD v1.70): one frame per line is

--- a/dashboard/mock/state.ts
+++ b/dashboard/mock/state.ts
@@ -15,6 +15,8 @@ interface MockService {
   scaling?: { min: number; max: number; metrics: { name: string; target: number }[] }
   expose?: { domains: string[]; port: number; tlsMode: string }
   isFunction?: boolean
+  /** Init steps (R32), in declaration order. */
+  inits?: { name: string; image: string }[]
 }
 
 export interface MockAlloc {
@@ -69,6 +71,15 @@ export const services: MockService[] = [
     count: 2,
     image: 'registry.example.com/shop/api:0.9.1',
     generation: 2,
+    // The two canonical init shapes (R32): a wait on a dependency from a
+    // sidecar image, and a migration on the task's own image - the shape
+    // v1.99's deploy-follow exists for. This service having steps is what
+    // puts the Container picker on its Logs card in dev:mock; no fixture
+    // exercised it before v0.31.1 and the schema's wrong key went unseen.
+    inits: [
+      { name: 'wait-for-postgres', image: 'busybox:1.36' },
+      { name: 'migrate', image: 'registry.example.com/shop/api:0.9.1' },
+    ],
   },
   {
     project: 'shop',
@@ -152,6 +163,10 @@ export function desiredJSON(svc: MockService) {
       : null,
     Scaling: svc.scaling ?? null,
     ...(svc.isFunction ? { runtime: 'wasm', function: { module: svc.image } } : {}),
+    // Lowercase `init`, as Desired's json tag marshals it (post-v1.84 fields
+    // all are). The dashboard schema said `Init` until v0.31.1, and because
+    // this mock never served the key at all, dev:mock could not catch it.
+    ...(svc.inits ? { init: svc.inits.map((i) => ({ name: i.name, image: i.image })) } : {}),
     spec_hash: specHash(svc),
   }
 }
@@ -378,6 +393,44 @@ export function logLine(svc: MockService): { alloc_id: string; line: string } | 
   const samples = logSamples[svc.service] ?? ['tick']
   const line = samples[Math.floor(Math.random() * samples.length)] ?? 'tick'
   return { alloc_id: alloc.id, line: `${new Date().toISOString().slice(11, 19)} ${line}` }
+}
+
+/** Per-step init transcripts: what each of shop/api's steps would have said. */
+const initLogSamples: Record<string, string[]> = {
+  'wait-for-postgres': [
+    'waiting for postgres.shop.kanea:5432…',
+    'not ready (attempt 1)',
+    'not ready (attempt 2)',
+    'postgres.shop.kanea:5432 accepting connections',
+  ],
+  migrate: [
+    'alembic: context impl PostgresqlImpl',
+    'alembic: 3 revisions pending',
+    'alembic: running upgrade 8f2c41 -> 9a01d7, add order index',
+    'alembic: running upgrade 9a01d7 -> b44e02, widen sku column',
+    'alembic: running upgrade b44e02 -> c91f3a, backfill currencies',
+    'alembic: done in 2.4s',
+  ],
+}
+
+/**
+ * initLogLines is the whole of one step's log, at once: a sequence runs once
+ * per service per spec hash, on alloc index 0 (v1.92), and its file stops
+ * growing the moment the step exits - so the honest mock is a finite
+ * transcript served on subscribe, never a stream. That difference is visible
+ * in dev:mock on purpose: a picker that kept "streaming" init lines would be
+ * a friendlier contract than the daemon's.
+ */
+export function initLogLines(
+  svc: MockService,
+  container: string,
+): { alloc_id: string; line: string }[] {
+  if (!svc.inits?.some((i) => i.name === container)) return []
+  const startedAgo = 36 * 3600 * 1000 // beside the leader alloc's created_at
+  return (initLogSamples[container] ?? [`${container}: done`]).map((line, i) => ({
+    alloc_id: `${svc.project}-${svc.service}-0`,
+    line: `${new Date(startedAt - startedAgo + i * 700).toISOString().slice(11, 19)} ${line}`,
+  }))
 }
 
 // ---- rollouts ----

--- a/dashboard/src/lib/api.test.ts
+++ b/dashboard/src/lib/api.test.ts
@@ -38,6 +38,27 @@ describe('servicesResponseSchema', () => {
     })
     expect(result.success).toBe(false)
   })
+
+  // The key is lowercase `init`, as Desired's json tag marshals it. The schema
+  // said `Init` until v0.31.1 and no test fed it a real payload, so zod
+  // silently stripped the daemon's key and the init log picker and sequence
+  // row never rendered on a real node. This fixture is the daemon's actual
+  // shape; keep it lowercase.
+  it('parses init steps under the lowercase key the daemon sends', () => {
+    const parsed = servicesResponseSchema.parse({
+      services: [
+        {
+          Project: 'shop',
+          Service: 'web',
+          Count: 1,
+          Image: 'ghcr.io/acme/web:v1',
+          Resources: { CPUMillis: 0, MemoryBytes: 0 },
+          init: [{ name: 'migrate', image: 'ghcr.io/acme/web:v1' }],
+        },
+      ],
+    })
+    expect(parsed.services?.[0]?.init?.map((s) => s.name)).toEqual(['migrate'])
+  })
 })
 
 describe('logBatchSchema', () => {

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -46,8 +46,11 @@ export const scalingPolicySchema = z.object({
 })
 
 // One init container: a step run to completion before the task (R32). The
-// outer key is PascalCase (Desired's field is untagged) while the inner fields
-// carry json tags, the same split every nested type here has.
+// The outer key is lowercase `init` like the inner fields: the whole feature
+// is post-v1.84, so Desired's field carries a json tag - unlike the untagged
+// PascalCase fields that predate the convention. The schema said `Init` until
+// v0.31.1 and the picker never rendered on a real node: zod strips unknown
+// keys, so the lowercase payload parsed cleanly to a null field.
 export const initContainerSchema = z.object({
   name: z.string(),
   image: z.string(),
@@ -83,7 +86,7 @@ export const serviceSchema = z.object({
   // absent on every record written before the fields existed, and pull_policy
   // is empty whenever the node's own default applies - which is not a value to
   // render as "none".
-  Init: z.array(initContainerSchema).nullish(),
+  init: z.array(initContainerSchema).nullish(),
   pull_policy: z.string().optional(),
   // v1.39: a service lowered from a `function` block. The marker is what the
   // Functions page filters on and the Services page filters out: one record,

--- a/dashboard/src/pages/ServiceDetail.tsx
+++ b/dashboard/src/pages/ServiceDetail.tsx
@@ -249,7 +249,7 @@ export function ServiceDetail({ project, service }: { project: string; service: 
             </CardContent>
           </Card>
 
-          <LogPanel project={project} service={service} inits={desired?.Init ?? []} />
+          <LogPanel project={project} service={service} inits={desired?.init ?? []} />
 
           <EdgePanel edge={stats.data?.edge} />
         </div>
@@ -722,11 +722,11 @@ function SpecPanel({ desired }: { desired: Service | undefined }) {
             {desired.pull_policy}
           </KeyValue>
         ) : null}
-        {(desired.Init ?? []).length > 0 ? (
+        {(desired.init ?? []).length > 0 ? (
           <KeyValue label="Init" mono>
             {/* In declaration order, which is run order (R32). */}
             <span className="break-all">
-              {(desired.Init ?? []).map((step) => step.name).join(' → ')}
+              {(desired.init ?? []).map((step) => step.name).join(' → ')}
             </span>
           </KeyValue>
         ) : null}

--- a/dashboard/src/test/mockState.test.ts
+++ b/dashboard/src/test/mockState.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { servicesResponseSchema } from '@/lib/api'
+import { findService, initLogLines, servicesPayload } from '../../mock/state'
+
+// The mock's contract is its header comment: shapes match src/lib's zod
+// schemas, and a field the schemas would reject is a bug here, not there.
+// This parse is that sentence as a test - it is also the pairing that would
+// have caught v0.31.1's bug from the other side, where the schema's `Init`
+// key rejected nothing because the mock served no init steps at all.
+describe('the mock daemon serves what the real schemas accept', () => {
+  it('parses the services payload, init steps included', () => {
+    const parsed = servicesResponseSchema.parse(servicesPayload())
+    const api = parsed.services?.find((s) => s.Service === 'api')
+    expect(api?.init?.map((s) => s.name)).toEqual(['wait-for-postgres', 'migrate'])
+  })
+
+  it('serves an init transcript on the leader alloc, and only for declared steps', () => {
+    const api = findService('shop', 'api')
+    if (!api) throw new Error('the shop/api fixture is gone')
+    const lines = initLogLines(api, 'migrate')
+    expect(lines.length).toBeGreaterThan(0)
+    // v1.92: a sequence runs once per service, on alloc index 0.
+    expect(new Set(lines.map((l) => l.alloc_id))).toEqual(new Set(['shop-api-0']))
+    expect(initLogLines(api, 'no-such-step')).toEqual([])
+  })
+})


### PR DESCRIPTION
## What & why

`Desired.Init` has marshalled as lowercase `init` since the feature shipped (`json:"init,omitempty"`, v1.84), but the dashboard's `serviceSchema` declared the key PascalCase `Init` - with a comment asserting the field was untagged. zod strips unknown keys, so every real payload parsed cleanly to a null field: the **Container picker in the Logs card and the init sequence row never rendered on a real node**, and init logs were unreachable from the dashboard even though the socket subscription, `useLiveLog`'s `container` parameter, and the picker itself all shipped working in v0.24.0.

No test ever fed the schema a payload carrying init steps, which is how the mismatch survived five releases. The fix is the key and its three consumers; the new fixture is the daemon's actual marshalled shape, pinned lowercase with the story in a comment.

## Checklist

- [x] This change follows `PRD.md`, or the PRD was amended first in this PR (AGENTS.md constraint #1) - no PRD change: this makes the page render what v1.84 already specified
- [x] `make check` passes locally (vet, test, lint, security gates) - `make dashboard` green (lint, typecheck, test, build, audit)
- [x] No secrets/credentials added (gitleaks-clean); secrets are `secret:`-referenced, never inlined
- [x] Metrics/logs did not touch the Store; mutations go through `Store` with monotonic indexes (no Go changes)
- [x] New API/WS/MCP routes are deny-by-default behind auth middleware (none added)
- [x] Tests added/updated (table-driven; reconciler & jobspec >80% coverage)
- [x] Docs updated (`PRD.md`, `AGENTS.md`, `docs/`) where behavior changed - none needed; the docs already describe the feature as built

🤖 Generated with [Claude Code](https://claude.com/claude-code)