### PR TITLE
docs: release prep for v0.32.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ and a **keyless cosign** signature over the checksums. The SBOMs are listed in
 the checksums, so that one signature covers them too:
 
 ```bash
-VERSION=v0.31.1; ARCH=amd64
+VERSION=v0.32.0; ARCH=amd64
 BASE=https://github.com/m18h/kanea/releases/download/$VERSION
 
 curl -fLO $BASE/kanea_${VERSION#v}_linux_$ARCH.tar.gz

--- a/site/index.html
+++ b/site/index.html
@@ -389,7 +389,7 @@
     </nav>
     <div style="flex:1"></div>
     <div style="display:flex;flex-wrap:wrap;align-items:center;gap:10px 16px;font-family:'Spline Sans Mono',monospace;font-size:12px;color:var(--muted-3);">
-      <span>v0.31.1</span>
+      <span>v0.32.0</span>
       <button sc-camel-on-click="{{ toggleTheme }}" title="Toggle light and dark" aria-label="Toggle light and dark" style="display:flex;align-items:center;justify-content:center;width:32px;height:31px;padding:0;border:1px solid var(--line-3);background:transparent;color:var(--muted-3);cursor:pointer;" style-hover="color:var(--text);border-color:var(--line-strong)">
         <sc-if value="{{ isDark }}" hint-placeholder-val="{{ false }}">
           <svg width="15" height="15" sc-camel-view-box="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M2 12h2M20 12h2M4.9 4.9l1.5 1.5M17.6 17.6l1.5 1.5M19.1 4.9l-1.5 1.5M6.4 17.6l-1.5 1.5"></path></svg>


### PR DESCRIPTION
## What & why

The release-checklist walk for cutting v0.32.0 (AGENTS.md, Releases): the two version strings that name a release — `VERSION=` in the README's manual-install example and the bare `<span>` in the site header — bumped to the tag being cut. The checklist grep `grep -rn "v0\.31\." README.md site/` found nothing else live; the remaining hits correctly name the releases features shipped in.

The rest of the checklist was already satisfied by the feature PRs (#128, #131, #130): docs describe what ships (remove verb, `logs --previous`, init log fixes in README + site reference), PRD version references read v1.101 everywhere and match `PRD.md`'s header, and `docs/DECISIONS.md` carries the v1.100 and v1.101 amendment bullets.

Tag v0.32.0 is cut from main once this lands.

## Checklist

- [x] This change follows `PRD.md`, or the PRD was amended first in this PR (AGENTS.md constraint #1) — docs only
- [x] `make check` passes locally (vet, test, lint, security gates) — no code change
- [x] No secrets/credentials added (gitleaks-clean); secrets are `secret:`-referenced, never inlined
- [x] Metrics/logs did not touch the Store; mutations go through `Store` with monotonic indexes — n/a
- [x] New API/WS/MCP routes are deny-by-default behind auth middleware — n/a
- [x] Tests added/updated (table-driven; reconciler & jobspec >80% coverage) — n/a
- [x] Docs updated (`PRD.md`, `AGENTS.md`, `docs/`) where behavior changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HznBuJE15rzHfod9D7h6Ud