### PR TITLE
test(jobspec): pin env_from reaching init containers

### DIFF
--- a/internal/jobspec/envgroup_test.go
+++ b/internal/jobspec/envgroup_test.go
@@ -87,6 +87,68 @@ func TestTheServicesOwnEnvWinsOverAGroup(t *testing.T) {
 // TestOneGroupResolvesPerProject is why a group is evaluated once per consuming
 // service rather than once per spec: the service-reference namespace is
 // project-scoped, so the same group means two different addresses.
+// TestEnvGroupsReachInitContainers pins the R34/R32 intersection resolve.go
+// promises in prose: env_from is a statement about the service, so every
+// container of the alloc - the task and each init step - takes the groups as
+// its base, and each container's own env wins on top, separately. The
+// canonical use is exactly a migration step: reading the same DATABASE_URL
+// the app reads, without repeating it, so the two cannot drift.
+func TestEnvGroupsReachInitContainers(t *testing.T) {
+	const src = `spec_version = 1
+project "shop" {}
+
+env_group "common" {
+  LOG_LEVEL = "info"
+  APP_ENV   = "staging"
+}
+
+service "web" {
+  project  = "shop"
+  env_from = ["common"]
+  init "migrate" {
+    image   = "app:v1"
+    command = ["migrate"]
+    env = {
+      LOG_LEVEL = "debug"
+    }
+  }
+  task "app" {
+    image = "app:v1"
+    env = {
+      APP_ENV = "production"
+    }
+  }
+}
+`
+	spec, diags := parseSpec(t, src)
+	if diags.HasErrors() {
+		t.Fatalf("refused: %s", jobspec.FormatDiagnostics(diags))
+	}
+	svc := spec.ServiceByName("shop", "web")
+	initEnv := svc.Inits[0].Env
+	taskEnv := svc.Task.Env
+
+	if initEnv["APP_ENV"] != "staging" {
+		t.Errorf("init APP_ENV = %q, want the group's %q: an init step is one of the "+
+			"service's containers, and env_from is a statement about the service",
+			initEnv["APP_ENV"], "staging")
+	}
+	if initEnv["LOG_LEVEL"] != "debug" {
+		t.Errorf("init LOG_LEVEL = %q, want debug: the step's own env must win over a group",
+			initEnv["LOG_LEVEL"])
+	}
+	// And the overrides stay with their containers: neither block's env may
+	// leak into the other's.
+	if taskEnv["APP_ENV"] != "production" {
+		t.Errorf("task APP_ENV = %q, want production: the task's own env must win over a group",
+			taskEnv["APP_ENV"])
+	}
+	if taskEnv["LOG_LEVEL"] != "info" {
+		t.Errorf("task LOG_LEVEL = %q, want the group's info: the init's override leaked "+
+			"into the task", taskEnv["LOG_LEVEL"])
+	}
+}
+
 func TestOneGroupResolvesPerProject(t *testing.T) {
 	spec, diags := parseSpec(t, twoProjectSpec)
 	if diags.HasErrors() {


### PR DESCRIPTION
## What & why

Answering "does init read env_from?" turned up that the answer — yes, deliberately, per resolve.go's own comment ("env_from is a statement about the service, so scoping it to the task alone would make it mean something narrower than where it is written", R34) — was implemented but never test-pinned for the init half. `envgroup_test.go` covered the task thoroughly and never mentioned an init block.

This adds the pin: a group's keys form every container's base env, the task's and each init step's own `env` win on top **separately**, and neither block's override leaks into the other. The canonical use is exactly a migration step reading the same `DATABASE_URL` the app reads, without repeating it.

Test-only; no behavior change.

## Checklist

- [x] This change follows `PRD.md` (pins R34 × R32 as specified)
- [x] `make check` passes locally — lint carries only the pre-existing darwin-only `datapath.New` staticcheck artifact
- [x] No secrets/credentials added
- [x] Metrics/logs did not touch the Store — n/a
- [x] New API/WS/MCP routes are deny-by-default — n/a
- [x] Tests added/updated (table stays >80% on jobspec)
- [x] Docs — n/a (no behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HznBuJE15rzHfod9D7h6Ud