### PR TITLE
chore(release): version strings for v0.33.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ and a **keyless cosign** signature over the checksums. The SBOMs are listed in
 the checksums, so that one signature covers them too:
 
 ```bash
-VERSION=v0.32.0; ARCH=amd64
+VERSION=v0.33.0; ARCH=amd64
 BASE=https://github.com/m18h/kanea/releases/download/$VERSION
 
 curl -fLO $BASE/kanea_${VERSION#v}_linux_$ARCH.tar.gz

--- a/site/index.html
+++ b/site/index.html
@@ -389,7 +389,7 @@
     </nav>
     <div style="flex:1"></div>
     <div style="display:flex;flex-wrap:wrap;align-items:center;gap:10px 16px;font-family:'Spline Sans Mono',monospace;font-size:12px;color:var(--muted-3);">
-      <span>v0.32.0</span>
+      <span>v0.33.0</span>
       <button sc-camel-on-click="{{ toggleTheme }}" title="Toggle light and dark" aria-label="Toggle light and dark" style="display:flex;align-items:center;justify-content:center;width:32px;height:31px;padding:0;border:1px solid var(--line-3);background:transparent;color:var(--muted-3);cursor:pointer;" style-hover="color:var(--text);border-color:var(--line-strong)">
         <sc-if value="{{ isDark }}" hint-placeholder-val="{{ false }}">
           <svg width="15" height="15" sc-camel-view-box="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M2 12h2M20 12h2M4.9 4.9l1.5 1.5M17.6 17.6l1.5 1.5M19.1 4.9l-1.5 1.5M6.4 17.6l-1.5 1.5"></path></svg>


### PR DESCRIPTION
Pre-tag docs bump for **v0.33.0** (per the AGENTS.md release checklist — the tag is the last step). Bumps the two release-naming strings that drift silently:

- `README.md` — `VERSION=v0.32.0` → `v0.33.0` in the manual-install example.
- `site/index.html` — the header `<span>` version → `v0.33.0`.

PRD references (README doc table, AGENTS header) already track **v1.105**, matching `PRD.md`. New user-visible behaviour since v0.32.0 — the hardening posture (`hardening = "restricted"`, `read_only_rootfs`, plan warnings), `--require-signature`, the slim `/healthz`, project stop/remove, and inline spec edit — is documented in `site/docs/index.html` and the PRD. The BuildKit `v0.32.0` strings elsewhere are a component version, not the release, and are left alone.

Merge this, then `v0.33.0` gets tagged on the merged commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)