### PR TITLE
docs: release prep for v0.34.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ and a **keyless cosign** signature over the checksums. The SBOMs are listed in
 the checksums, so that one signature covers them too:
 
 ```bash
-VERSION=v0.33.0; ARCH=amd64
+VERSION=v0.34.0; ARCH=amd64
 BASE=https://github.com/m18h/kanea/releases/download/$VERSION
 
 curl -fLO $BASE/kanea_${VERSION#v}_linux_$ARCH.tar.gz
@@ -803,6 +803,16 @@ so a typo cannot silently stop working replication) and **notification channels*
 Accounts, API tokens and the audit log live there too, one tab each. What
 stays read-only is what belongs to the unit: listen address, subnets, DNS and
 the published-port policy, each shown with a note saying so.
+
+The version in the sidebar is a control for an admin: a dot appears beside it
+when a newer release is published, and clicking it opens a dialog that checks
+for updates or runs the upgrade - the same fetch-verify-backup-restart
+sequence as `sudo kanea upgrade`, run by the daemon on itself. The check never
+runs unprompted: the node asks GitHub only while an admin has the dialog open,
+and caches the answer for an hour. There is no downgrade over the API
+(`--allow-downgrade` stays on the node's CLI), and outside systemd the new
+binary is staged with a note that a restart is required, rather than
+restarted into. A viewer keeps the plain version text.
 
 If your LAN already uses `10.244.0.0/16`, move Kanea's:
 

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -876,6 +876,24 @@ runs any state migrations. Running workloads are untouched throughout.</pre>
       version means nothing to download, so running it twice is safe by construction.
     </p>
 
+    <p>
+      Since v0.34.0 an admin can run the same flow from the dashboard. The version in
+      the sidebar grows a dot when a newer release is published; clicking it opens a
+      dialog that checks for updates or installs one (<code>GET</code> and
+      <code>POST /v1/upgrade</code>, admin-only, audited). The daemon performs the
+      sequence above on itself - pre-upgrade backup, fetch and verify, atomic
+      install - then answers the request, restarts <code>kanea-edge</code>, and exits
+      into systemd's <code>Restart=always</code>; the page reloads once the new
+      version answers health, which is also what swaps in the new embedded dashboard.
+      The check never runs unprompted: the node asks GitHub only while an admin has
+      the dashboard open, and caches the answer for an hour, so a node never phones
+      home on its own. There is no downgrade over the API
+      (<code>--allow-downgrade</code> stays CLI-on-the-node), and outside systemd
+      nothing restarts: the binary is installed and the response says
+      <code>restart_required</code>. <code>KANEA_REQUIRE_SIGNATURE=1</code> on the
+      unit gives this path the <code>--require-signature</code> posture.
+    </p>
+
     <div class="tablewrap">
       <table>
         <thead><tr><th>Flag</th><th>Meaning</th></tr></thead>
@@ -1377,7 +1395,11 @@ External:  containerd  ·  buildkitd  ·  Linux kernel (eBPF, cgroups v2, netfil
       (node-wide defaults and per-project, each with a test button); plus accounts, API
       tokens and the audit log, one tab each; what belongs to the unit (listen address,
       subnets, DNS, the
-      port policy) is shown read-only with a note saying so. The MCP server exposes 24 tools
+      port policy) is shown read-only with a note saying so. The version in the sidebar is
+      itself a control for an admin: a dot marks a newer published release, and the
+      dialog behind it checks for or installs one, the daemon restarting into it (the
+      <a href="#install-upgrade">upgrade flow</a>, run by the node on itself; a viewer
+      keeps the plain text). The MCP server exposes 24 tools
       in three tiers (read, mutate, destructive) over stdio and streamable HTTP.
     </p>
     <div class="callout">

--- a/site/index.html
+++ b/site/index.html
@@ -389,7 +389,7 @@
     </nav>
     <div style="flex:1"></div>
     <div style="display:flex;flex-wrap:wrap;align-items:center;gap:10px 16px;font-family:'Spline Sans Mono',monospace;font-size:12px;color:var(--muted-3);">
-      <span>v0.33.0</span>
+      <span>v0.34.0</span>
       <button sc-camel-on-click="{{ toggleTheme }}" title="Toggle light and dark" aria-label="Toggle light and dark" style="display:flex;align-items:center;justify-content:center;width:32px;height:31px;padding:0;border:1px solid var(--line-3);background:transparent;color:var(--muted-3);cursor:pointer;" style-hover="color:var(--text);border-color:var(--line-strong)">
         <sc-if value="{{ isDark }}" hint-placeholder-val="{{ false }}">
           <svg width="15" height="15" sc-camel-view-box="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M2 12h2M20 12h2M4.9 4.9l1.5 1.5M17.6 17.6l1.5 1.5M19.1 4.9l-1.5 1.5M6.4 17.6l-1.5 1.5"></path></svg>
@@ -851,7 +851,7 @@ class Component extends DCLogic {
       { name: 'kanea-edge', role: 'north–south traffic', kind: 'DATA PLANE', title: 'A separate process on purpose', body: 'The edge is not a child of the control plane, so restarting kanead never drops a request in flight. TLS is issued in the control plane and published here.', note: 'routes · middleware in fixed order · h2c behind' },
       { name: 'eBPF datapath', role: 'east–west, no CNI', kind: 'NETWORK', title: 'Three programs, compiled in', body: 'Connect-time service load balancing, per-project default-deny policy, and per-alloc plumbing. No network agent, no kvstore, no CNI - the programs travel inside the binary.', note: 'internal DNS · service VIPs · the autoscaler\u2019s own counters' },
       { name: 'containerd', role: 'hardened runtime', kind: 'RUNTIME', title: 'No privileged escape hatch', body: 'Capabilities dropped to a reviewed uid-switching baseline, no-new-privileges, the default seccomp profile, per-alloc PID and IPC namespaces. Workloads share a cgroup with a hard ceiling; the control plane holds a memory floor beneath it.', note: 'installed by kanea init, pinned by SHA-256' },
-      { name: 'dashboard', role: 'embedded, one socket', kind: 'INTERFACE', title: 'Served by the daemon itself', body: 'React and shadcn/ui embedded in the binary, over one multiplexed websocket: services, allocs, events, streaming logs, rollout progress - and a shell into any running alloc, from the browser.', note: 'kanea ui' },
+      { name: 'dashboard', role: 'embedded, one socket', kind: 'INTERFACE', title: 'Served by the daemon itself', body: 'React and shadcn/ui embedded in the binary, over one multiplexed websocket: services, allocs, events, streaming logs, rollout progress, a shell into any running alloc - and the upgrade itself: an admin installs a new release from the sidebar, and the daemon restarts into it.', note: 'kanea ui' },
       { name: 'mcp server', role: '20 tools, three tiers', kind: 'AGENTS', title: 'An agent can operate the platform', body: 'Over stdio and streamable HTTP. Tools reach the platform only over its own HTTP API - never a side channel - and no tool at any tier returns a secret.', note: 'deny-by-default on every route, audited' }
     ];
   }


### PR DESCRIPTION
## What

The release checklist, walked for v0.34.0 (last tag v0.33.0; #153 is a feature, so minor bump):

1. **Docs describe what ships.** The one user-visible feature since v0.33.0 is the dashboard upgrade control (#153, PRD v1.107), which deferred its site updates to this PR. Added: a paragraph in README's dashboard section, a paragraph in site/docs' Upgrading section (the API path: admin-only, demand-only check with 1h cache, no downgrade over the API, staged outside systemd, `KANEA_REQUIRE_SIGNATURE=1`), a clause in site/docs' architecture dashboard paragraph, and an extension of the site's dashboard feature card. DR_RUNBOOK untouched on purpose: backup/restore behaviour did not move - `POST /v1/upgrade` reuses the existing pre-upgrade backup flow.
2. **Version strings**: `VERSION=v0.34.0` in README's manual-install example and `<span>v0.34.0</span>` in the site header. The checklist grep for `v0\.33\.` over README and site/ now finds nothing live.
3. **PRD refs**: already v1.107 in README and AGENTS.md (landed with #153); matches PRD.md's header.
4. **DECISIONS.md bullet**: the v1.107 amendment bullet landed with #153.
5. This PR is the docs-before-tag step; the tag follows its merge.

⚠️ The feature-card copy is a hand edit to the design-tool export's inline string (no `{{ }}` touched, no em dashes, JS still parses). Per AGENTS.md, mirror it in the tool or the next re-export drops it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)