### PR TITLE
ci: pull MinIO from quay.io, same digest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
             -e MINIO_ROOT_USER=kaneatest \
             -e MINIO_ROOT_PASSWORD=kaneatestsecret \
             -e MINIO_DOMAIN=localhost \
-            minio/minio@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e \
+            quay.io/minio/minio@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e \
             server /data
           for _ in $(seq 1 30); do
             if curl -fsS http://127.0.0.1:9000/minio/health/live >/dev/null 2>&1; then


### PR DESCRIPTION
## What & why

Docker Hub now denies pulls of `minio/minio` ("pull access denied … repository does not exist or may require 'docker login'"), which kills the S3 interop job in ~19s before a test runs - on any branch, including main's next push. MinIO's own registry serves the identical manifest: `quay.io/v2/minio/minio/manifests/sha256:14cea…` answers 200 for the exact digest already pinned. The pin does not move; only the registry in front of it.

## Checklist

- [x] This change follows `PRD.md`, or the PRD was amended first in this PR (AGENTS.md constraint #1) - CI infra only, no behavior change
- [x] `make check` passes locally (vet, test, lint, security gates)
- [x] No secrets/credentials added (gitleaks-clean); secrets are `secret:`-referenced, never inlined
- [x] Metrics/logs did not touch the Store; mutations go through `Store` with monotonic indexes - n/a
- [x] New API/WS/MCP routes are deny-by-default behind auth middleware - n/a
- [x] Tests added/updated - n/a: the job itself is the test
- [x] Docs updated where behavior changed - n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)